### PR TITLE
Fix breadcrumb issues

### DIFF
--- a/volto/src/customizations/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/volto/src/customizations/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -77,29 +77,29 @@ class Breadcrumbs extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
+    const hasBreadcrumbItems = this.props.items && this.props.items.length >= 1;
+
     return (
-      <dev>
-        <Container>
-          <GOVUK.Breadcrumbs>
-            <GOVUK.Breadcrumbs.Link
-              href={this.props.root || '/'}
-            >
-              <Icon name={homeSVG} size="18px" />
+      <Container>
+        {hasBreadcrumbItems && <GOVUK.Breadcrumbs id="ddcms_breadcrumbs">
+          <GOVUK.Breadcrumbs.Link
+            href={this.props.root || '/'}
+          >
+            Home
+          </GOVUK.Breadcrumbs.Link>
+          {this.props.items.map((item, index, items) =>
+            <GOVUK.Breadcrumbs.Link href={item.url}>
+              {item.title}
             </GOVUK.Breadcrumbs.Link>
-            {this.props.items.map((item, index, items) =>
-              <GOVUK.Breadcrumbs.Link href={item.url}>
-                {item.title}
-              </GOVUK.Breadcrumbs.Link>
-            )}
-          </GOVUK.Breadcrumbs>
-          <GOVUK.PhaseBanner level="beta">
-            This part of GOV.UK is being rebuilt –{' '}
-            <Link to="https://example.com">
-              find out what that means
-            </Link>
-          </GOVUK.PhaseBanner>
-        </Container>
-      </dev>
+          )}
+        </GOVUK.Breadcrumbs>}
+        <GOVUK.PhaseBanner level="beta">
+          This part of GOV.UK is being rebuilt –{' '}
+          <Link to="https://example.com">
+            find out what that means
+          </Link>
+        </GOVUK.PhaseBanner>
+      </Container>
     );
   }
 }

--- a/volto/src/styles/overrides.css
+++ b/volto/src/styles/overrides.css
@@ -1,0 +1,3 @@
+#ddcms_breadcrumbs a {
+    text-decoration: underline;
+}

--- a/volto/src/theme.js
+++ b/volto/src/theme.js
@@ -1,2 +1,3 @@
 import 'semantic-ui-less/semantic.less';
 import '@plone/volto/../theme/themes/pastanaga/extras/extras.less';
+import './styles/overrides.css';


### PR DESCRIPTION
Makes the breadcrumb component look like GOV.UK one - https://design-system.service.gov.uk/components/breadcrumbs/

Hides breadcrumb on home page

Introduces an overrides CSS file to resolve clashes with GOV.UK styles and Volto theme styles