### PR TITLE
Plone data persistence

### DIFF
--- a/docker-compose-deploy-cc1.yml
+++ b/docker-compose-deploy-cc1.yml
@@ -6,8 +6,8 @@ services:
             context: plone-5
         ports:
             - 8080:8080
-#        volumes:
-#            - plone-data:/data:z
+        volumes:
+            - plone-data:/data:z
         networks:
             - cogs_proxy
     volto:


### PR DESCRIPTION
Tiny change to just use a named volume for Plone's `/data` directory and so persist the ZODB over container restarts.

Needs testing on climate-1.ukstats.dev before merge.