### PR TITLE
Minor build/deploy issues

### DIFF
--- a/volto/.dockerignore
+++ b/volto/.dockerignore
@@ -12,3 +12,4 @@
 !src
 !theme
 !mrs.developer.json
+**/node_modules

--- a/volto/yarn.lock
+++ b/volto/yarn.lock
@@ -21539,7 +21539,7 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-volto-authomatic@*:
+volto-authomatic@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/volto-authomatic/-/volto-authomatic-1.0.3.tgz#084eb9e59579eee91de5d97f035b3e0e746043b8"
   integrity sha512-NP6lmddD3qmMsd6CSgMAPiS7zrLxQLq1UmIgny5FFvMtoMNl4Y+cJKEqlqaVi3V6qV7Hq28NbvAyGeXNVzRgzw==


### PR DESCRIPTION
yarn.lock was missing a pin. Avoid sending GBs of node_modules in docker context for build.