### PR TITLE
Include chart-builder v0.3.0 with dynamic choropleth data

### DIFF
--- a/volto/mrs.developer.json
+++ b/volto/mrs.developer.json
@@ -7,6 +7,6 @@
   },
   "chart-builder": {
     "url": "https://github.com/GSS-Cogs/chart-builder/",
-    "branch": "v0.2.2"
+    "tag": "v0.3.0"
   }
 }

--- a/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
@@ -100,6 +100,11 @@ export function useBlockChartContextState(props) {
     'selectedDimensions',
     [],
   );
+  const [sparqlQuery, setSparqlQuery] = useVoltoBlockDataState(
+    data,
+    'sparqlQuery',
+    '',
+  );
 
   const [mapData, setMapData] = useVoltoBlockDataState(data, 'mapData', []);
   const [geoJson, setGeoJson] = useVoltoBlockDataState(data, 'geoJson', []);
@@ -131,6 +136,7 @@ export function useBlockChartContextState(props) {
         dataSelection: JSON.stringify(dataSelection),
         selectedColumns: JSON.stringify(selectedColumns),
         selectedDimensions: JSON.stringify(selectedDimensions),
+        sparqlQuery: JSON.stringify(sparqlQuery),
       });
     });
   }, [
@@ -142,6 +148,7 @@ export function useBlockChartContextState(props) {
     dataSelection,
     selectedColumns,
     selectedDimensions,
+    sparqlQuery,
   ]);
 
   return {
@@ -161,6 +168,8 @@ export function useBlockChartContextState(props) {
     setMapData,
     geoJson,
     setGeoJson,
+    sparqlQuery,
+    setSparqlQuery,
   };
 }
 


### PR DESCRIPTION
Closes #171 

This can be tested by adding a Chart block in volto, switching the chart to "Map" mode, and using a SPARQL query from https://github.com/GSS-Cogs/chart-builder/wiki#sparql-data-sources

- [ ] You see a choropleth map populated by the data from the sparql query.
- [ ] After saving the document, the content appears in the document you added a chart to
- [ ] Editing the content, the sparql query is preserved and you can edit the other map properties

