### PR TITLE
Bump chart builder version

### DIFF
--- a/volto/mrs.developer.json
+++ b/volto/mrs.developer.json
@@ -7,6 +7,6 @@
   },
   "chart-builder": {
     "url": "https://github.com/GSS-Cogs/chart-builder/",
-    "tag": "v0.3.0"
+    "tag": "v0.3.1"
   }
 }


### PR DESCRIPTION
Closes #173 

I introduced a major performance regression in volto-chart-builder when I made importCsv/EeaData functions non-memoized; this fixes them.

Acceptance is a sanity check of https://github.com/GSS-Cogs/chart-builder/commit/86ecf303b2ac77d4b3d80a3cad1b96922664b2f9 

And when you edit a chart in volto, after selecting data, your browser and eventually entire computer don't crash...
