### PR TITLE
Add another Plone backend with its own volume.

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,6 +10,15 @@ services:
             - cogs_proxy
         restart: always
 
+    plone-cc2:
+        build:
+            context: ../plone-5
+        volumes:
+            - cc2-data:/data:z
+        networks:
+            - cogs_proxy
+        restart: always
+
     volto-v1:
         build:
             context: ../volto
@@ -46,6 +55,7 @@ services:
 
 volumes:
     plone-data:
+    cc2-data:
 
 networks:
     cogs_proxy:

--- a/volto/vhosts.d/climate-2.ukstats.dev
+++ b/volto/vhosts.d/climate-2.ukstats.dev
@@ -1,5 +1,5 @@
 location ~ /api($|/.*) {
   rewrite ^/api($|/.*) /VirtualHostBase/https/climate-2.ukstats.dev:443/Plone/VirtualHostRoot/_vh_api$1 break;
-  proxy_pass http://plone:8080;
+  proxy_pass http://plone-cc2:8080;
 }
 rewrite ^(/\+\+plone\+\+static/.*)$ /api/$1 last;


### PR DESCRIPTION
I've not tested this yet, but it just adds a new Plone backend service along with its own data volume, to separate things out from the CC1 site and also allow different configuration of the Plone site, e.g. install different packages or edit default views, etc.