### PR TITLE
Issue 145/csv connector data

### DIFF
--- a/plone-5/instance/src/ukstats.article_type/src/ukstats.article_type.egg-info/SOURCES.txt
+++ b/plone-5/instance/src/ukstats.article_type/src/ukstats.article_type.egg-info/SOURCES.txt
@@ -36,6 +36,7 @@ src/ukstats/article_type/locales/__init__.py
 src/ukstats/article_type/locales/ukstats.article_type.pot
 src/ukstats/article_type/locales/update.py
 src/ukstats/article_type/locales/update.sh
+src/ukstats/article_type/locales/en/LC_MESSAGES/ukstats.article_type.mo
 src/ukstats/article_type/locales/en/LC_MESSAGES/ukstats.article_type.po
 src/ukstats/article_type/profiles/default/browserlayer.xml
 src/ukstats/article_type/profiles/default/catalog.xml

--- a/plone-5/instance/src/ukstats.csv_type/README.rst
+++ b/plone-5/instance/src/ukstats.csv_type/README.rst
@@ -1,64 +1,9 @@
-.. This README is meant for consumption by humans and pypi. Pypi can render rst files so please do not use Sphinx features.
-   If you want to learn more about writing documentation, please check out: http://docs.plone.org/about/documentation_styleguide.html
-   This text does not appear on pypi or github. It is a comment.
-
-.. image:: https://github.com/collective/ukstats.csv_type/actions/workflows/plone-package.yml/badge.svg
-    :target: https://github.com/collective/ukstats.csv_type/actions/workflows/plone-package.yml
-
-.. image:: https://coveralls.io/repos/github/collective/ukstats.csv_type/badge.svg?branch=main
-    :target: https://coveralls.io/github/collective/ukstats.csv_type?branch=main
-    :alt: Coveralls
-
-.. image:: https://codecov.io/gh/collective/ukstats.csv_type/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/collective/ukstats.csv_type
-
-.. image:: https://img.shields.io/pypi/v/ukstats.csv_type.svg
-    :target: https://pypi.python.org/pypi/ukstats.csv_type/
-    :alt: Latest Version
-
-.. image:: https://img.shields.io/pypi/status/ukstats.csv_type.svg
-    :target: https://pypi.python.org/pypi/ukstats.csv_type
-    :alt: Egg Status
-
-.. image:: https://img.shields.io/pypi/pyversions/ukstats.csv_type.svg?style=plastic   :alt: Supported - Python Versions
-
-.. image:: https://img.shields.io/pypi/l/ukstats.csv_type.svg
-    :target: https://pypi.python.org/pypi/ukstats.csv_type/
-    :alt: License
-
-
 ================
 ukstats.csv_type
 ================
 
-Tell me what your product does
-
-Features
---------
-
-- Can be bullet points
-
-
-Examples
---------
-
-This add-on can be seen in action at the following sites:
-- Is there a page on the internet where everybody can see the features?
-
-
-Documentation
--------------
-
-Full documentation for end users can be found in the "docs" folder, and is also available online at http://docs.plone.org/foo/bar
-
-
-Translations
-------------
-
-This product has been translated into
-
-- Klingon (thanks, K'Plai)
-
+A simple CSV content type for Plone that can expose the contained
+data in a manner compatible with EEA data connectors.
 
 Installation
 ------------
@@ -74,35 +19,6 @@ Install ukstats.csv_type by adding it to your buildout::
 
 
 and then running ``bin/buildout``
-
-
-Authors
--------
-
-Provided by awesome people ;)
-
-
-Contributors
-------------
-
-Put your name here, you deserve it!
-
-- ?
-
-
-Contribute
-----------
-
-- Issue Tracker: https://github.com/collective/ukstats.csv_type/issues
-- Source Code: https://github.com/collective/ukstats.csv_type
-- Documentation: https://docs.plone.org/foo/bar
-
-
-Support
--------
-
-If you are having issues, please let us know.
-We have a mailing list located at: project@example.com
 
 
 License

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats.csv_type.egg-info/PKG-INFO
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats.csv_type.egg-info/PKG-INFO
@@ -9,67 +9,12 @@ License: GPL version 2
 Project-URL: PyPI, https://pypi.python.org/pypi/ukstats.csv_type
 Project-URL: Source, https://github.com/collective/ukstats.csv_type
 Project-URL: Tracker, https://github.com/collective/ukstats.csv_type/issues
-Description: .. This README is meant for consumption by humans and pypi. Pypi can render rst files so please do not use Sphinx features.
-           If you want to learn more about writing documentation, please check out: http://docs.plone.org/about/documentation_styleguide.html
-           This text does not appear on pypi or github. It is a comment.
-        
-        .. image:: https://github.com/collective/ukstats.csv_type/actions/workflows/plone-package.yml/badge.svg
-            :target: https://github.com/collective/ukstats.csv_type/actions/workflows/plone-package.yml
-        
-        .. image:: https://coveralls.io/repos/github/collective/ukstats.csv_type/badge.svg?branch=main
-            :target: https://coveralls.io/github/collective/ukstats.csv_type?branch=main
-            :alt: Coveralls
-        
-        .. image:: https://codecov.io/gh/collective/ukstats.csv_type/branch/master/graph/badge.svg
-            :target: https://codecov.io/gh/collective/ukstats.csv_type
-        
-        .. image:: https://img.shields.io/pypi/v/ukstats.csv_type.svg
-            :target: https://pypi.python.org/pypi/ukstats.csv_type/
-            :alt: Latest Version
-        
-        .. image:: https://img.shields.io/pypi/status/ukstats.csv_type.svg
-            :target: https://pypi.python.org/pypi/ukstats.csv_type
-            :alt: Egg Status
-        
-        .. image:: https://img.shields.io/pypi/pyversions/ukstats.csv_type.svg?style=plastic   :alt: Supported - Python Versions
-        
-        .. image:: https://img.shields.io/pypi/l/ukstats.csv_type.svg
-            :target: https://pypi.python.org/pypi/ukstats.csv_type/
-            :alt: License
-        
-        
-        ================
+Description: ================
         ukstats.csv_type
         ================
         
-        Tell me what your product does
-        
-        Features
-        --------
-        
-        - Can be bullet points
-        
-        
-        Examples
-        --------
-        
-        This add-on can be seen in action at the following sites:
-        - Is there a page on the internet where everybody can see the features?
-        
-        
-        Documentation
-        -------------
-        
-        Full documentation for end users can be found in the "docs" folder, and is also available online at http://docs.plone.org/foo/bar
-        
-        
-        Translations
-        ------------
-        
-        This product has been translated into
-        
-        - Klingon (thanks, K'Plai)
-        
+        A simple CSV content type for Plone that can expose the contained
+        data in a manner compatible with EEA data connectors.
         
         Installation
         ------------
@@ -85,35 +30,6 @@ Description: .. This README is meant for consumption by humans and pypi. Pypi ca
         
         
         and then running ``bin/buildout``
-        
-        
-        Authors
-        -------
-        
-        Provided by awesome people ;)
-        
-        
-        Contributors
-        ------------
-        
-        Put your name here, you deserve it!
-        
-        - ?
-        
-        
-        Contribute
-        ----------
-        
-        - Issue Tracker: https://github.com/collective/ukstats.csv_type/issues
-        - Source Code: https://github.com/collective/ukstats.csv_type
-        - Documentation: https://docs.plone.org/foo/bar
-        
-        
-        Support
-        -------
-        
-        If you are having issues, please let us know.
-        We have a mailing list located at: project@example.com
         
         
         License

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats.csv_type.egg-info/SOURCES.txt
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats.csv_type.egg-info/SOURCES.txt
@@ -18,6 +18,7 @@ src/ukstats.csv_type.egg-info/not-zip-safe
 src/ukstats.csv_type.egg-info/requires.txt
 src/ukstats.csv_type.egg-info/top_level.txt
 src/ukstats/csv_type/__init__.py
+src/ukstats/csv_type/adapter.py
 src/ukstats/csv_type/configure.zcml
 src/ukstats/csv_type/csv.py
 src/ukstats/csv_type/interfaces.py
@@ -28,9 +29,7 @@ src/ukstats/csv_type/browser/__init__.py
 src/ukstats/csv_type/browser/configure.zcml
 src/ukstats/csv_type/browser/overrides/.gitkeep
 src/ukstats/csv_type/browser/static/.gitkeep
-src/ukstats/csv_type/content/__init__.py
 src/ukstats/csv_type/content/csv_type.py
-src/ukstats/csv_type/content/csv_type.xml
 src/ukstats/csv_type/locales/README.rst
 src/ukstats/csv_type/locales/__init__.py
 src/ukstats/csv_type/locales/ukstats.csv_type.pot

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
@@ -28,7 +28,6 @@ class DataProviderForCsvws(object):
     @ram.cache(lambda func, self: (self.context.modified(), self.request.form))
     def _provided_data(self):
         """ provided data """
-        print(self.context.csv)
 
         results = {}
         reader = csv.reader(StringIO(self.context.csv.data.decode('utf8')))

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from io import StringIO
+import csv
 from plone.memoize import ram
 from zope.component import adapter
 from zope.interface import implementer
@@ -26,11 +28,21 @@ class DataProviderForCsvws(object):
     @ram.cache(lambda func, self: (self.context.modified(), self.request.form))
     def _provided_data(self):
         """ provided data """
-        return {
-            "results": {
-                "a CSV w derived field": True
-            }
-        }
+        print(self.context.csv)
+
+        results = {}
+        reader = csv.reader(StringIO(self.context.csv.data.decode('utf8')))
+        headers = False
+        for row in reader:
+            if not headers:
+                headers = row
+                for col in row:
+                    results[col] = []
+            else:
+                for index, val in enumerate(row):
+                    results[headers[index]].append(val)
+
+        return results
 
     @property
     def provided_data(self):

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
@@ -1,0 +1,38 @@
+""" behavior module """
+
+import logging
+
+from plone.memoize import ram
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+
+from eea.api.dataconnector.interfaces import IDataProvider
+from ukstats.csv_type.content.csv_type import ICSVMarker
+
+logger = logging.getLogger(__name__)
+
+
+@adapter(ICSVMarker, IBrowserRequest)
+@implementer(IDataProvider)
+class DataProviderForCsvws(object):
+    """ data provider for connectors """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    # TO DO: persistent caching, periodical refresh, etc
+    @ram.cache(lambda func, self: (self.context.modified(), self.request.form))
+    def _provided_data(self):
+        """ provided data """
+        return {
+            "results": {
+                "a CSV w derived field": True
+            }
+        }
+
+    @property
+    def provided_data(self):
+        """ provided data """
+        return self._provided_data()

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/configure.zcml
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/configure.zcml
@@ -18,6 +18,8 @@
   <include file="permissions.zcml" />
   <!-- <include file="behavior.zcml" /> -->
 
+    <adapter factory=".adapter.DataProviderForCsvws" />
+
   <genericsetup:registerProfile
       name="default"
       title="CSV Content Type"

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/content/csv_type.py
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/content/csv_type.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from plone.dexterity.content import Container
+
+
+class ICSVMarker(Container):
+    """ Another marker """

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/content/csv_type.py
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/content/csv_type.py
@@ -3,4 +3,8 @@ from plone.dexterity.content import Container
 
 
 class ICSVMarker(Container):
-    """ Another marker """
+    """
+    Marker interface that defines the content type,
+    and allows us to target an adapter to produce
+    @connector-data compatible output.
+    """

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/profiles/default/types/csv_type.xml
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/profiles/default/types/csv_type.xml
@@ -21,7 +21,7 @@
   </property>
   <!-- Schema, class and security -->
   <property name="add_permission">ukstats.csv_type.AddCSVType</property>
-  <property name="klass">plone.dexterity.content.Container</property>
+  <property name="klass">ukstats.csv_type.content.csv_type.ICSVMarker</property>
   <property name="model_file"></property>
   <property name="model_source"></property>
   <property name="schema">ukstats.csv_type.csv.ICSV</property>

--- a/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
@@ -33,7 +33,7 @@ const Edit = (props) => {
               title="Data file"
               widgetOptions={{
                 pattern_options: {
-                  selectableTypes: ['File', 'discodataconnector', 'sparql_dataconnector'],
+                  selectableTypes: ['File', 'discodataconnector', 'sparql_dataconnector', 'csv_type'],
                 }
               }}
               value={data.file_path || []}

--- a/volto/src/addons/volto-chart-builder/src/hooks/index.js
+++ b/volto/src/addons/volto-chart-builder/src/hooks/index.js
@@ -21,6 +21,7 @@ export function usePloneCsvData(plone_ref) {
           break;
         case 'discodataconnector':
         case 'sparql_dataconnector':
+        case 'csv_type':
           dispatch(getChartBuilderData(contentRef['@id'], '@connector-data'));
           break;
       }
@@ -39,6 +40,7 @@ export function usePloneCsvData(plone_ref) {
           break;
         case 'discodataconnector':
         case 'sparql_dataconnector':
+        case 'csv_type':
           importEeaData(content.content, contentRef['@id']);
           break;
       }


### PR DESCRIPTION
Closes #145 

Adds @connector-data support to our CSV content type, and allows chart builder to use it.
