### PR TITLE
Fix chart builder extension parsing of schema properties

### DIFF
--- a/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
@@ -48,10 +48,13 @@ const Edit = (props) => {
   );
 };
 
-function migrateFromPropertiesSchemaAndValue(chartPropertiesSchema) {
-  return chartPropertiesSchema.reduce((acc, section) => {
+function migrateFromPropertiesSchemaAndValue(storedSchema) {
+  return ChartPropertiesSchema.reduce((acc, section) => {
+    const storedSection = storedSchema.find(x => x.name.toLowerCase() === section.name.toLowerCase());
     acc[section.name] = section.properties.reduce((acc, prop) => {
-      acc[prop.name] = prop.value;
+      const storedValue = storedSection?.properties?.find(x => x.name.toLowerCase() === prop.name.toLowerCase());
+      // if (!storedValue) console.warn('Did not find', section.name, prop.name);
+      acc[prop.name] = storedValue ? storedValue.value : prop.defaultValue;
       return acc;
     }, {});
     return acc;


### PR DESCRIPTION
- this fixes problems with "Unknown field e[t.name]" in prod
- bare-bones fix for the current hard crashes

Helps with #238 but not a total fix, so leaving the issue open