### PR TITLE
Fix main content margins & masthead exception

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/GssCogsElements/CcHeroHeader/CcHeroHeaderView.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/GssCogsElements/CcHeroHeader/CcHeroHeaderView.jsx
@@ -9,7 +9,7 @@ import './CcHeroHeader.scss';
 export const CcHeroHeaderView = (props) => {
   return (
     <CcMasthead className="cc-masthead-wrapper--bottom-overlap cc-masthead-wrapper--hero">
-      <div className="cc-hero-header govuk-width-container">
+      <div className="cc-hero-header volto-width-container--wide">
         <div className="cc-hero-header--content">
           <div className="cc-hero-header--update-type">
             <Tag className="govuk-tag--grey">New Article</Tag> 20 January 2022

--- a/volto/src/addons/volto-climatechange-elements/src/GssCogsElements/CcMasthead/CcMasthead.scss
+++ b/volto/src/addons/volto-climatechange-elements/src/GssCogsElements/CcMasthead/CcMasthead.scss
@@ -12,6 +12,6 @@
   }
 
   &--bottom-overlap {
-    margin-bottom: govuk-spacing(-8);
+    margin-bottom: govuk-spacing(-9);
   }
 }

--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/App/App.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/App/App.jsx
@@ -129,7 +129,7 @@ class App extends Component {
         />
         <SkipLinks />
         <Header pathname={path} />
-        <Breadcrumbs pathname={path} />
+        {this.props.pathname !== '/' && <Breadcrumbs pathname={path} />}
         <MultilingualRedirector pathname={this.props.pathname}>
           <main>
             <OutdatedBrowser />

--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
@@ -50,7 +50,9 @@ class Header extends Component {
               })
             ),
           ]}
+          productName="Climate Change "
           className="Header"
+          containerClassName="volto-width-container--wide"
         />
       </>
     );

--- a/volto/src/styles/custom.scss
+++ b/volto/src/styles/custom.scss
@@ -32,5 +32,8 @@
 
 .volto-width-container--wide {
   @include govuk-width-container(1920px);
-  padding: 16px;
+}
+
+main > * > * > :not(.cc-masthead-wrapper) {
+  @include govuk-width-container(1920px);
 }


### PR DESCRIPTION
Avoid breadcrumbs on root of site.
Use volto-width-container--wide instead of govuk-width-container.
Add more overlap on tiles.
Remove padding in .volto-width-container--wide.
Apply .volto-width-container--wide to all body blocks except .cc-masthead-wrapper.
Use productName Climate Change in header.