### PR TITLE
staging deploy fails due to SSH git repo URL

### DIFF
--- a/plone-5/instance/custom.cfg
+++ b/plone-5/instance/custom.cfg
@@ -32,4 +32,4 @@ profiles += kitconcept.volto:default
 eea.api.dataconnector = 1.8
 
 [sources]
-ukstats.ccv2.theme = git git@github.com:GSS-Cogs/ukstats.ccv2.theme.git
+ukstats.ccv2.theme = git https://github.com/GSS-Cogs/ukstats.ccv2.theme.git


### PR DESCRIPTION
Use HTTPS git repo URL as Jenkins doesn't have SSH.