### PR TITLE
Tweak default sparql endpoint. Fix sparql input size.

### DIFF
--- a/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/interfaces.py
+++ b/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/interfaces.py
@@ -1,16 +1,9 @@
 # -*- coding: utf-8 -*-
 """Module where all interfaces, events and exceptions live. Based on eea.api.dataconnector add-on"""
-from plone.app.z3cform.widget import QueryStringFieldWidget
 from plone import schema
-from plone.autoform.interfaces import IFormFieldProvider
-from plone.autoform import directives as form
 from plone.dexterity.content import Container
 from plone.supermodel import model
-from zope.interface import provider
-from zope.interface import Interface
-from zope.interface import Attribute
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
-from eea.api.dataconnector.interfaces import IBasicDataProvider
 
 
 class IUkstatsSparqlDataconnectorLayer(IDefaultBrowserLayer):
@@ -35,7 +28,7 @@ class ISPARQLDataConnectorSchema(model.Schema):
     endpoint_url = schema.TextLine(
         title="SPARQL endpoint URL",
         required=True,
-        default="https://beta.gss-data.org.uk/sparql",
+        default="https://staging.gss-data.org.uk/sparql",
     )
     sparql_query = schema.Text(
         title="SPARQL Query",

--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/App/App.css
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/App/App.css
@@ -1,0 +1,5 @@
+#field-sparql_query {
+  min-height: 300px;
+}
+
+

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/App/App.css
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/App/App.css
@@ -25,3 +25,7 @@ main {
   margin: 0;
 }
 
+#field-sparql_query {
+  min-height: 300px;
+}
+


### PR DESCRIPTION
- seems like a CSS hack is the only way to fix the size
- looking at volto source, there doesn't seem to be a
  way to thread a "rows" prop to the <textarea>