### PR TITLE
Issue 267/data connector preview

### DIFF
--- a/plone-5/instance/custom.cfg
+++ b/plone-5/instance/custom.cfg
@@ -29,7 +29,7 @@ profiles += kitconcept.volto:default
             ukstats.ccv2.theme:content
 
 [versions]
-eea.api.dataconnector = 1.8
+eea.api.dataconnector = 2.3
 
 [sources]
 ukstats.ccv2.theme = git https://github.com/GSS-Cogs/ukstats.ccv2.theme.git

--- a/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
+++ b/plone-5/instance/src/ukstats.csv_type/src/ukstats/csv_type/adapter.py
@@ -41,7 +41,10 @@ class DataProviderForCsvws(object):
                 for index, val in enumerate(row):
                     results[headers[index]].append(val)
 
-        return results
+        return {
+            "results": results,
+            "metadata": {},
+        }
 
     @property
     def provided_data(self):

--- a/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
+++ b/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
@@ -61,7 +61,10 @@ class SPARQLDataProviderForConnectors(object):
         data = self._get_data()
 
         rotate_data = self.change_orientation(data['head']['vars'], data["results"]["bindings"])
-        return rotate_data
+        return {
+            "results": rotate_data,
+            "metadata": {},
+        }
 
     @property
     def provided_data(self):

--- a/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
@@ -18,7 +18,7 @@ const View = () => {
 
 const Edit = (props) => {
   const { selected, onChangeBlock, block, data } = props;
-  usePloneCsvData(data.file_path || []);
+  const { error: dataError } = usePloneCsvData(data.file_path || []);
   const { error: geoJsonError } = usePloneGeoJson(data.geojson_path || []);
 
   return (
@@ -36,6 +36,7 @@ const Edit = (props) => {
                   widget="object_browser"
                   mode="link"
                   title="Data file"
+                  error={dataError}
                   widgetOptions={{
                     pattern_options: {
                       selectableTypes: [

--- a/volto/src/addons/volto-chart-builder/src/hooks/index.js
+++ b/volto/src/addons/volto-chart-builder/src/hooks/index.js
@@ -4,6 +4,7 @@ import { ChartContext, convertSparqlToGeoJson } from 'gss-cogs-chart-builder';
 import { getChartBuilderData } from '../actions';
 
 export function usePloneCsvData(plone_ref) {
+  const [error, setError] = useState([]);
   const {
     importCsvData,
     importEeaData,
@@ -16,7 +17,7 @@ export function usePloneCsvData(plone_ref) {
 
   const contentRef = plone_ref.length ? plone_ref[0] : null;
 
-  const content = useSelector((state) =>
+  const response = useSelector((state) =>
     contentRef ? state.chartBuilderRawData.get(contentRef['@id']) : null,
   );
 
@@ -36,30 +37,38 @@ export function usePloneCsvData(plone_ref) {
   }, [contentRef, dispatch]);
 
   useEffect(() => {
-    if (content != null && contentRef != null && content.loaded) {
+    if (response != null && contentRef != null && response.loaded) {
+      setError([]);
       if (chartType === 'Map') {
-        setMapData(content.content.data);
+        setMapData(response.content.data);
       } else {
         switch (contentRef['@type']) {
           case 'File':
-            importCsvData(content.content, contentRef['@id']);
+            importCsvData(response.content, contentRef['@id']);
             break;
           case 'discodataconnector':
           case 'sparql_dataconnector':
           case 'csv_type':
-            importEeaData(content.content, contentRef['@id']);
+            importEeaData(response.content, contentRef['@id']);
             break;
         }
       }
     }
+
+    if (response != null && contentRef != null && response.error) {
+      setError([response.error.message]);
+    }
+
   }, [
-    content,
+    response,
     contentRef,
     importCsvData,
     importEeaData,
     setMapData,
     chartType,
   ]);
+
+  return { error }
 }
 
 export function usePloneGeoJson(plone_ref) {

--- a/volto/src/addons/volto-chart-builder/src/hooks/index.js
+++ b/volto/src/addons/volto-chart-builder/src/hooks/index.js
@@ -49,7 +49,10 @@ export function usePloneCsvData(plone_ref) {
           case 'discodataconnector':
           case 'sparql_dataconnector':
           case 'csv_type':
-            importEeaData(response.content, contentRef['@id']);
+            importEeaData({
+              id: response.content.id,
+              data: response.content.data.results,
+            }, contentRef['@id']);
             break;
         }
       }
@@ -84,17 +87,17 @@ export function usePloneGeoJson(plone_ref) {
     }
   }, [contentRef, dispatch]);
 
-  const content = useSelector((state) =>
+  const response = useSelector((state) =>
     contentRef ? state.chartBuilderRawData.get(contentRef['@id']) : null,
   );
 
   useEffect(() => {
-    if (content != null && contentRef != null && content.loaded) {
-      if (content.content?.data?.boundary) {
+    if (response != null && contentRef != null && response.loaded) {
+      if (response.content?.data?.boundary) {
         // content.content.data: { boundary: string[] } the strings are json fragments
         setGeoJson(
           convertSparqlToGeoJson({
-            boundary: content.content.data.boundary.map((x) => JSON.parse(x)),
+            boundary: response.content.data.boundary.map((x) => JSON.parse(x)),
           }),
         );
         setError([]);
@@ -102,7 +105,10 @@ export function usePloneGeoJson(plone_ref) {
         setError(['GEOJSON data must have a "boundary" property']);
       }
     }
-  }, [content, contentRef, setGeoJson]);
+    if (response != null && contentRef != null && response.error) {
+      setError([response.error.message]);
+    }
+  }, [response, contentRef, setGeoJson]);
 
   return {
     error,

--- a/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/DashboardTileEdit.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/DashboardTileEdit.jsx
@@ -26,7 +26,7 @@ export const DashboardTileEdit = (props) => {
                         formData={data}
                         errors={{
                           ...(props.errors || {}),
-                          data_source: dataSourceErrors,
+                          ...(dataSourceErrors.length ? { data_source: dataSourceErrors } : {}),
                         }}
                     />
                 </Segment.Group>

--- a/volto/src/addons/volto-climatechange-elements/src/index.js
+++ b/volto/src/addons/volto-climatechange-elements/src/index.js
@@ -64,6 +64,7 @@ const applyConfig = (config) => {
   config.views.layoutViews.cc_preview = CcV2ArticleView;
   config.views.layoutViews.cc_preview2 = CcV2Overview;
   config.views.contentTypesViews.sparql_dataconnector = config.views.contentTypesViews.discodataconnector;
+  config.views.contentTypesViews.csv_type = config.views.contentTypesViews.discodataconnector;
 
   config.addonReducers.relatedItemsData = relatedItemsData;
 

--- a/volto/src/addons/volto-climatechange-elements/src/index.js
+++ b/volto/src/addons/volto-climatechange-elements/src/index.js
@@ -63,6 +63,7 @@ const applyConfig = (config) => {
 
   config.views.layoutViews.cc_preview = CcV2ArticleView;
   config.views.layoutViews.cc_preview2 = CcV2Overview;
+  config.views.contentTypesViews.sparql_dataconnector = config.views.contentTypesViews.discodataconnector;
 
   config.addonReducers.relatedItemsData = relatedItemsData;
 


### PR DESCRIPTION
Closes #267 

This branch exploits our `@connector-data` compatibility to re-use the `@eeacms/volto-datablocks` `contentTypeView` for discodata connectors to preview our `sparql_dataconnector` results.

It turned out I made a mistake during the plone-15 upgrade thinking the `volto-datablocks` upgrade I made worked with the version of `eea.api.dataconnector` we were using; it didn't. So this PR includes an upgrade for the data connector, and includes the tweaks necessary across our components that use `@connector-data` to use the v2 results.

With that in place, you can view the sparql results when viewing a piece of sparql content.

I've also added yet more error handling in our connected data components to show errors in the object browser if something incompatible is selected.

This still uses our `chartBuilderRawData` reducer, which was put in place before I had spotted the `connectToProviderDataUnfiltered.js` that eea has. I'll ticket that separately.
