### PR TITLE
Use multi-stage build

### DIFF
--- a/tests/climate-change-v2/docker-compose.yml
+++ b/tests/climate-change-v2/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     environment:
       - RAZZLE_API_PATH=http://climate-change.data.gov.uk/api
       - NODE_ENV=production
-    command: "yarn start:prod"
     networks:
       - test_net
 

--- a/volto/Dockerfile
+++ b/volto/Dockerfile
@@ -1,15 +1,32 @@
-FROM node:14 as stage1
+FROM node:14-alpine3.15 as stage1
 
 ARG ADDONS
 ENV ADDONS=$ADDONS
 
-WORKDIR /app
+RUN apk --no-cache add git && \
+    mkdir -p /build && \
+    chown -R node:node /build
+USER node
+WORKDIR /build
 # restrict files/directories to copy in .dockerignore
-COPY . /app/
+COPY --chown=node . /build/
+
 ENV BUILD_TARGET=server
 RUN yarn global add mrs-developer
 RUN yarn develop
-RUN yarn install --frozen-lockfile && yarn cache clean
+RUN yarn install --frozen-lockfile
 RUN yarn build
+RUN yarn install --frozen-lockfile --prod
 
-CMD yarn start
+FROM node:14-alpine3.15
+RUN mkdir -p /app && \
+    chown -R node:node /app
+USER node
+WORKDIR /app
+
+COPY --from=stage1 /build/build /app/build/
+COPY --from=stage1 /build/node_modules /app/node_modules/
+COPY package.json yarn.lock /app/
+
+EXPOSE 3000
+CMD yarn start:prod


### PR DESCRIPTION
Reduce resulting image size to 900MB:

Targets production:
* Use multi-stage build.
* Use node user rather than root to build and run.
* Copy only essentials for production/server.
* `yarn start:prod`
* Use Alpine node image base.