### PR TITLE
Add missing .results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,8 +55,8 @@ pipeline {
                 }
                 dir('tests/climate-change-v2') {
                     cucumber 'test-results.json'
+                    sh "docker-compose down"
                 }
-                sh "docker-compose down"
             }
         }
     }

--- a/volto/src/addons/volto-climatechange-elements/src/hooks/index.js
+++ b/volto/src/addons/volto-climatechange-elements/src/hooks/index.js
@@ -40,7 +40,7 @@ export function useTileVisData(plone_ref) {
         && Array.isArray(response.content.data?.results?.x)
         && Array.isArray(response.content.data?.results?.y)
       ) {
-        setSparkLineData(response.content.data.x.map((xVal, index) => [xVal, response.content.data.y[index]]));
+        setSparkLineData(response.content.data.results.x.map((xVal, index) => [xVal, response.content.data.results.y[index]]));
       }
 
       if (


### PR DESCRIPTION
Exported the plone site from staging.climate-change.data.gov.uk using the /api/manage page, and loaded the resulting zexp to a local Plone (mounting my local working directory via docker-compose.yaml, copying the Plone.zexp file to /data/instance/import, opening up port 8080 and logging into the root of the Plone instance, deleting the existing Plone site, then importing the zexp), though it may have been easier to use @rossbowen 's method of pointing the RAZZLE_API to staging.climate-change.data.gov.uk/api.

Fixes and closes #329 