### PR TITLE
Fix styling for Volto main headings

### DIFF
--- a/volto/src/addons/volto-govuk-theme/theme/_custom.scss
+++ b/volto/src/addons/volto-govuk-theme/theme/_custom.scss
@@ -24,11 +24,15 @@
 }
 
 // hide the purple accent line from Volto main headings
-.documentFirstHeading::before {
+h1.documentFirstHeading::before {
   border-bottom: none;
+}
+
+// hide the grey underline from Volto main headings
+h1.documentFirstHeading {
+  border: none;
 }
 
 .volto-width-container--wide {
   @include govuk-width-container(1920px);
 }
-


### PR DESCRIPTION
- Use a more specific selector to remove the purple underline accent to give the rule priority over the Volto theme
- Also remove grey underline from main headings

Closes #333 