### PR TITLE
Plone 5.2.7

### DIFF
--- a/plone-5/Dockerfile
+++ b/plone-5/Dockerfile
@@ -1,4 +1,4 @@
-FROM plone:5.2.5-python38
+FROM plone:5.2.7-python38
 
 COPY instance/custom.cfg /plone/instance/
 COPY instance/src /plone/instance/src/

--- a/plone-5/bootstrap.sh
+++ b/plone-5/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-plone=$(docker create plone:5.2.5)
+plone=$(docker create plone:5.2.7)
 for f in base.cfg buildout-base.cfg buildout.cfg develop.cfg lxml_static.cfg requirements.txt
 do
   docker cp $plone:/plone/instance/$f instance/$f

--- a/plone-5/instance/src/ukstats.article_type/src/ukstats.article_type.egg-info/requires.txt
+++ b/plone-5/instance/src/ukstats.article_type/src/ukstats.article_type.egg-info/requires.txt
@@ -3,6 +3,7 @@ z3c.jbot
 plone.api>=1.8.4
 plone.restapi
 plone.app.dexterity
+plone.behavior
 
 [test]
 plone.app.testing

--- a/plone-5/plone-5.iml
+++ b/plone-5/plone-5.iml
@@ -25,26 +25,26 @@
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/cssselect-1.1.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/DateTime-4.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/decorator-4.4.2-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/diazo-1.4.1-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/diazo-1.4.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/DocumentTemplate-3.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/docutils-0.16-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/eea.api.dataconnector-1.8-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/eea.restapi-2.2-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/eea.api.dataconnector-2.3-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/eea.restapi-2.5-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/ExtensionClass-4.5.1-py3.8-linux-x86_64.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/feedparser-6.0.8-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/five.customerize-2.0.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/five.intid-1.2.6-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/five.localsitemanager-3.2.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/future-0.18.2-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/icalendar-4.0.7-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/icalendar-4.0.9-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/idna-2.10-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/jq-1.2.1-py3.8-linux-x86_64.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/jq-1.2.2-py3.8-linux-x86_64.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/jsonschema-3.2.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/kitconcept.volto-2.5.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/lxml-4.6.3-py3.8-linux-x86_64.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Markdown-3.2.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Missing-4.1-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/mockup-3.2.6-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/mockup-3.2.7-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/mo_dots-4.22.21108-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/mo_future-3.147.20327-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/mo_imports-3.149.20327-py3.8.egg" isTestSource="false" />
@@ -60,79 +60,79 @@
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/persistent-4.7.0-py3.8-linux-x86_64.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/piexif-1.1.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Pillow-6.2.2-py3.8-linux-x86_64.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Plone-5.2.5-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Plone-5.2.7-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.alterego-1.1.5-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.api-1.11.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.api-1.11.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.caching-2.1.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.content-3.8.8-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.contentlisting-2.0.3-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.contentmenu-2.3.3-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.contentlisting-2.0.6-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.contentmenu-2.3.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.contentrules-4.1.6-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.contenttypes-2.2.2-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.contenttypes-2.2.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.customerize-1.3.11-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.dexterity-2.6.9-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.discussion-3.4.4-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.event-3.2.12-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.dexterity-2.6.10-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.discussion-3.4.5-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.event-3.2.14-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.i18n-3.0.6-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.intid-1.1.4-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.iterate-4.0.1-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.layout-3.4.6-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.linkintegrity-3.4.1-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.locales-5.1.29-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.iterate-4.0.2-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.layout-3.5.1-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.linkintegrity-3.5.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.locales-5.1.30-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.lockingbehavior-1.0.7-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.multilingual-5.6.3-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.multilingual-5.6.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.portlets-4.4.7-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.querystring-1.4.14-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.querystring-1.4.15-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.redirector-2.2.1-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.registry-1.7.8-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.registry-1.7.9-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.relationfield-2.0.3-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.textfield-1.3.5-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.textfield-1.3.6-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.theming-4.1.7-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.upgrade-2.0.39-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.upgrade-2.1.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.users-2.6.6-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.uuid-2.0.2-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.versioningbehavior-1.4.3-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.versioningbehavior-1.4.5-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.viewletmanager-3.1.2-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.vocabularies-4.2.2-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.widgets-3.0.5-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.vocabularies-4.3.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.widgets-3.0.6-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.workflow-4.0.4-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.z3cform-3.2.2-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.app.z3cform-3.2.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.autoform-1.9.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.batching-1.1.7-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.behavior-1.4.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.browserlayer-2.2.4-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.cachepurging-2.0.3-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.cachepurging-2.0.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.caching-1.2.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.contentrules-2.1.2-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.dexterity-2.10.2-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.dexterity-2.10.5-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.event-1.4.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.folder-3.1.0-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.formwidget.namedfile-2.1.2-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.formwidget.recurrence-2.1.4-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.i18n-4.0.6-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.formwidget.namedfile-2.1.3-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.formwidget.recurrence-2.1.5-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.i18n-4.0.7-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.indexer-1.0.7-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.intelligenttext-3.1.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.keyring-3.1.3-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.locking-2.2.4-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.locking-2.2.5-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.memoize-2.1.1-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.namedfile-5.5.1-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.namedfile-5.6.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.outputfilters-4.0.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.portlet.collection-3.3.6-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.portlets-2.3.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.portlet.static-3.1.6-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.protect-4.1.6-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.recipe.zope2instance-6.10.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.recipe.zope2instance-6.10.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.registry-1.2.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.resource-2.1.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.resourceeditor-3.0.3-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.rest-2.0.0a1-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.restapi-8.12.1-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.rest-2.0.0a2-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.restapi-8.21.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.rfc822-2.0.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.scale-3.1.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.schema-1.3.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.schemaeditor-3.0.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.session-3.7.5-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.staticresources-1.4.3-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.staticresources-1.4.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.stringinterp-1.3.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.subrequest-1.9.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/plone.supermodel-1.6.3-py3.8.egg" isTestSource="false" />
@@ -150,21 +150,21 @@
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.CMFEditions-3.3.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.CMFFormController-4.1.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.CMFPlacefulWorkflow-2.0.4-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.CMFPlone-5.2.5-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.CMFPlone-5.2.7-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.CMFQuickInstallerTool-4.0.4-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.CMFUid-3.1.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.DateRecurringIndex-3.0.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.DCWorkflow-2.5.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.ExtendedPathIndex-4.0.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.ExternalMethod-4.5-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.GenericSetup-2.1.3-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.isurlinportal-1.2.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.GenericSetup-2.1.5-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.isurlinportal-1.2.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.MailHost-4.11-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.MimetypesRegistry-2.1.8-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.MimetypesRegistry-2.1.9-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.PlonePAS-6.0.8-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.PluggableAuthService-2.6.4-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.PluggableAuthService-2.7.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.PluginRegistry-1.9-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.PortalTransforms-3.1.11-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.PortalTransforms-3.1.12-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.PythonScripts-4.13-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.Sessions-4.9-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Products.SiteErrorLog-5.5-py3.8.egg" isTestSource="false" />
@@ -183,7 +183,7 @@
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/python_gettext-4.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/pytz-2021.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/Record-3.5-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/repoze.xmliter-0.6-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/repoze.xmliter-0.6.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/requests-2.25.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/RestrictedPython-5.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/roman-3.3-py3.8.egg" isTestSource="false" />
@@ -198,12 +198,12 @@
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/WebOb-1.8.7-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/WebTest-2.0.35-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/WSGIProxy2-0.4.6-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/XlsxWriter-3.0.2-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/XlsxWriter-3.0.3-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.autoinclude-0.4.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.caching-2.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.form-3.7.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.formwidget.query-0.17-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.jbot-1.1.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.jbot-1.1.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.objpath-1.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.pt-3.3.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/z3c.relationfield-0.9.0-py3.8.egg" isTestSource="false" />
@@ -243,7 +243,7 @@
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.filerepresentation-5.0.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.globalrequest-1.5-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.hookable-5.0.1-py3.8-linux-x86_64.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.i18n-4.7.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.i18n-4.8.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.i18nmessageid-5.0.1-py3.8-linux-x86_64.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.interface-5.4.0-py3.8-linux-x86_64.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.intid-4.3.0-py3.8.egg" isTestSource="false" />
@@ -256,7 +256,7 @@
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.ptresource-4.2.0-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.publisher-6.0.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.ramcache-2.3-py3.8.egg" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.schema-6.0.0-py3.8.egg" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.schema-6.1.1-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.security-5.1.1-py3.8-linux-x86_64.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.sendmail-5.2-py3.8.egg" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/buildout-cache/eggs/cp38/zope.sequencesort-4.1.2-py3.8.egg" isTestSource="false" />

--- a/tests/climate-change-v2/features/admin.feature
+++ b/tests/climate-change-v2/features/admin.feature
@@ -16,7 +16,7 @@ Feature: Administration
     And I type "admin" in the "#password" element
     And I take a screenshot
     When I press the "Enter" key
-    And I expect the element "#page-document" is visible
+    And I expect the element "#page-document" is visible after "5" seconds
 
   Scenario: add-ons installed
     Given I expect the element "#toolbar-personal" is visible


### PR DESCRIPTION
Update Plone 5.2.5 to 5.2.7
Brings in update to plone.restapi to fix #382 
Increase timeout in test for logging in as it was failing intermittently.
Update IntelliJ project dependencies and merge in #365.