### PR TITLE
Set a fixed height for dashboard tile value block labels

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/Bar/Bar.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/Bar/Bar.jsx
@@ -32,6 +32,7 @@ const Bar = ({ data, height }) => {
         yEnd={`${Math.floor(data[1].value)}%`}
         xColor={data[0].color}
         yColor={data[0].color}
+        isABar={true}
       />
     </Fragment>
   );

--- a/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/SparkLine/SparkLineContainer.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/SparkLine/SparkLineContainer.jsx
@@ -22,6 +22,7 @@ const SparkLineContainer = ({ data, lineColor }) => {
         yEnd={Number(yEnd).toFixed(2)}
         xColor={lineColor}
         yColor={lineColor}
+        isABar={false}
       />
     </Fragment>
   );

--- a/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/ValuesBlock/ValuesBlock.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/ValuesBlock/ValuesBlock.jsx
@@ -6,9 +6,21 @@
 // - xColor: string with the color for the x values
 // - yColor: string with the color for the y values
 
-const ValuesBlock = ({ xStart, xEnd, yStart, yEnd, xColor, yColor }) => {
+const ValuesBlock = ({
+  xStart,
+  xEnd,
+  yStart,
+  yEnd,
+  xColor,
+  yColor,
+  isABar,
+}) => {
+  let className = isABar
+    ? 'cc-dashboard-tile--values-bar'
+    : 'cc-dashboard-tile--values';
+
   return (
-    <div data-testid="values-block" className="cc-dashboard-tile--values">
+    <div data-testid="values-block" className={className}>
       <div className="cc-start-end-values" style={{ color: `${xColor}` }}>
         <div className="cc-xValue">{xStart}</div>
         <div className="cc-xValue">{xEnd}</div>

--- a/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/DashboardTile/TileVis/ValuesBlock/_valuesBlock.scss
+++ b/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/DashboardTile/TileVis/ValuesBlock/_valuesBlock.scss
@@ -1,6 +1,7 @@
 .cc-start-end-values {
   display: flex;
   justify-content: space-between;
+  align-items: flex-end;
 }
 
 .cc-xValue {

--- a/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/DashboardTile/_dashboardTile.scss
+++ b/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/DashboardTile/_dashboardTile.scss
@@ -1,7 +1,7 @@
 @import '../../colors.scss';
-@import "./TileVis/Bar/bar";
-@import "./TileVis/SparkLine/sparkLine";
-@import "./TileVis/ValuesBlock/valuesBlock";
+@import './TileVis/Bar/bar';
+@import './TileVis/SparkLine/sparkLine';
+@import './TileVis/ValuesBlock/valuesBlock';
 
 .cc-dashboard-tile {
   min-height: 400px;
@@ -19,6 +19,15 @@
   }
 
   &--values {
+    line-height: 24px;
+    padding-bottom: govuk-spacing(1);
+  }
+
+  &--values-bar {
+    height: 90px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
     line-height: 24px;
     padding-bottom: govuk-spacing(1);
   }


### PR DESCRIPTION
- Purpose of the change is to keep the horizontal stacked Bar vis centred with either one or two lines of values block label text
- Specific styling for dashboard tile values block when used with Bar vis
- Height set to 90px and flexbox justify-content: flex-end to keep label content at the bottom

Closes #349 