### PR TITLE
Figure block - allow sources without links

### DIFF
--- a/volto/src/addons/volto-chart-builder/src/components/Figure/FigureSourceView.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/FigureSourceView.jsx
@@ -5,9 +5,7 @@ export const FigureSourceView = ({ data }) => {
     { text: data.text, url: data.url },
     { text: data.text1, url: data.url1 },
     { text: data.text2, url: data.url2 },
-  ].filter(({ text, url }) => {
-    return text && url;
-  });
+  ].filter((source) => source.text !== '');
 
   const isLastItem = (index) => index == sources.length - 1;
 
@@ -17,9 +15,14 @@ export const FigureSourceView = ({ data }) => {
       {sources.map(({ text, url }, index) => {
         return (
           <span key={text}>
-            <a href={url} className="govuk-link">
-              {text}
-            </a>
+            {url ? (
+              <a href={url} className="govuk-link">
+                {text}
+              </a>
+            ) : (
+              <span>{text}</span>
+            )}
+
             {isLastItem(index) ? '' : ', '}
           </span>
         );


### PR DESCRIPTION
- Relax sources filter criteria to include any source where link text is provided
- Render an a href where url is available or otherwise a simple span with the label text

Closes #374 