### PR TITLE
Jenkins build hangs on test failure, part 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                         sh "docker-compose -p ${PROJ_NAME} up -d volto"
                         sh "docker-compose -p ${PROJ_NAME} up -d proxy"
                         def puppeteer = docker.image("${PROJ_NAME}_test")
-                        puppeteer.inside("--rm --entrypoint= --network ${PROJ_NAME}_test_net") { testContainer ->
+                        puppeteer.inside("--rm --entrypoint= --network ${PROJ_NAME}_test_net") {
                             sh './run.sh'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                         sh "docker-compose -p ${PROJ_NAME} up -d volto"
                         sh "docker-compose -p ${PROJ_NAME} up -d proxy"
                         def puppeteer = docker.image("${PROJ_NAME}_test")
-                        puppeteer.inside("--rm --entrypoint= --network ${PROJ_NAME}_test_net") {
+                        puppeteer.inside("--init --rm --entrypoint= --network ${PROJ_NAME}_test_net") {
                             sh './run.sh'
                         }
                     }


### PR DESCRIPTION
Try adding `--init` so that signals bubble up properly through PID1/init/tini.