### PR TITLE
ArticleHeader Updates

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/CcArticleHeader/CcArticleHeader.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcArticleHeader/CcArticleHeader.jsx
@@ -8,9 +8,9 @@ export const CcArticleHeader = ({ data }) => {
       <div className="cc-article-header app-width-container">
         <div className="govuk-!-padding-right-6">
           {data?.dashboard ? (
-            <p className="govuk-caption-m">Dashboard</p>
+            <p className="govuk-caption-l">Dashboard</p>
           ) : (
-            <p className="govuk-caption-m">Article</p>
+            <p className="govuk-caption-l">Article</p>
           )}
           <h1 className="govuk-heading-xl govuk-!-margin-bottom-6">
             {data.title}

--- a/volto/src/addons/volto-climatechange-elements/src/components/CcArticleHeader/CcArticleHeader.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcArticleHeader/CcArticleHeader.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
 
-import { CcRecentArticles } from '../CcArticleList/CcArticleList';
 import { CcMasthead } from '../CcMasthead/CcMasthead';
-import { FeedSignUps } from '../CcRelatedLinks/FeedSignUps';
 
 export const CcArticleHeader = ({ data }) => {
   return (
     <CcMasthead className="app-masthead--article">
       <div className="cc-article-header app-width-container">
         <div className="govuk-!-padding-right-6">
+          {data?.dashboard ? (
+            <p className="govuk-caption-m">Dashboard</p>
+          ) : (
+            <p className="govuk-caption-m">Article</p>
+          )}
           <h1 className="govuk-heading-xl govuk-!-margin-bottom-6">
             {data.title}
           </h1>
-          <p className="govuk-caption-m govuk-!-margin-bottom-6">
-            {data.created} by{' '}
-            <span className="cc-article-header__date">{data.creators}</span>
-          </p>
+          {data?.displayAuthors ? (
+            <p className="govuk-caption-m govuk-!-margin-bottom-6">
+              {data.created}
+              <span className="cc-article-header__date">{data.creators}</span>
+            </p>
+          ) : (
+            <p className="govuk-caption-m govuk-!-margin-bottom-6">
+              {data.created}
+            </p>
+          )}
           <p className="govuk-body-l">{data.summary}</p>
         </div>
       </div>

--- a/volto/src/addons/volto-climatechange-elements/src/components/CcV2Preview/CcV2ArticleView.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcV2Preview/CcV2ArticleView.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
 import { map } from 'lodash';
 import config from '@plone/volto/registry';
 import {
@@ -9,7 +8,6 @@ import {
 } from '@plone/volto/helpers';
 
 import { CcArticleHeader } from '../CcArticleHeader/CcArticleHeader';
-import { getRelatedItemsData } from '../../actions';
 import { formattedDate } from '../../utils';
 
 export const CcV2ArticleView = (props) => {
@@ -18,17 +16,6 @@ export const CcV2ArticleView = (props) => {
   const blocksLayoutFieldname = getBlocksLayoutFieldname(content);
 
   const formattedCreators = (creators) => creators.join(', ');
-
-  const dispatch = useDispatch();
-
-  const { data } = useSelector((state) => state.relatedItemsData);
-
-  useEffect(() => {
-    content.relatedItems.forEach((item) =>
-      dispatch(getRelatedItemsData(item['@id'])),
-    );
-  }, []);
-
   return (
     <div>
       <CcArticleHeader
@@ -37,7 +24,7 @@ export const CcV2ArticleView = (props) => {
           summary: content.description,
           created: formattedDate(content.created),
           creators: formattedCreators(content.creators),
-          relatedItems: data,
+          dashboard: content?.['@id'].includes('dashboard'),
         }}
       />
       <div className="volto-width-container--wide ccv2-article-body">


### PR DESCRIPTION
- Display of Authors / Creators are parameterised in the ArticleHeader
  component
- Caption added to note dashboard or article

This closes #431 and #432 
<img width="1292" alt="Screenshot 2022-06-30 at 22 05 08" src="https://user-images.githubusercontent.com/297400/176778316-bcfa42e0-e9d2-488e-9de1-0ed4c5867c9b.png">
<img width="1289" alt="Screenshot 2022-06-30 at 22 06 00" src="https://user-images.githubusercontent.com/297400/176778330-0a7e04ca-d32f-47a8-a232-ce54b1fdc72f.png">

