### PR TITLE
Figure block styling improvements

### DIFF
--- a/volto/src/addons/volto-chart-builder/src/components/Figure/figure.scss
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/figure.scss
@@ -1,9 +1,11 @@
 .figure {
-  margin-right: 32px;
   max-width: 1280px;
   margin-bottom: 32px;
+  margin-top: 32px;
+  margin-left: 0;
 
-  &__text {
+  &__text,
+  p {
     @media only screen and (min-width: 801px) {
       width: 66.7%;
     }
@@ -12,9 +14,28 @@
     }
   }
 
+  h2.figure__text {
+    font-size: 24px;
+  }
+
+  .js-plotly-plot {
+    margin-bottom: 16px;
+  }
+
+  ol {
+    padding-left: 16px;
+  }
+  li {
+    color: #505a5f;
+  }
+  li p {
+    font-size: 16px;
+    color: #505a5f;
+    margin-bottom: 8px;
+  }
+
   &--bg-white-smoke {
-    padding: 24px;
-    border: 1px solid #f3f2f1;
-    background: rgb(245, 245, 245);
+    padding-bottom: 32px;
+    border-bottom: 1px solid #505a5f;
   }
 }


### PR DESCRIPTION
- Reduce the figure heading font size
- Remove the white smoke colour background
- Remove the padding (creating extra space to view charts)
- Introduce a grey bottom border and padding to create space between charts
- Bring the numbered list of notes to be left aligned with the other text
- Style the numbered list of notes with correct font size and colour
- Enforce the 66.7% text width for `p` elements in freeform block text

Closes #434 