### PR TITLE
Phase Banner bottom border removed

### DIFF
--- a/volto/src/addons/volto-govuk-theme/theme/_custom.scss
+++ b/volto/src/addons/volto-govuk-theme/theme/_custom.scss
@@ -41,7 +41,7 @@ h1.documentFirstHeading {
   background-color: govuk-colour('light-grey');
 }
 
-.cc-phasebanner {
+div.cc-phasebanner {
   border-bottom: none;
 }
 


### PR DESCRIPTION
This closes #420. The bottom border removed to match figma
<img width="1316" alt="Screenshot 2022-07-04 at 14 16 32" src="https://user-images.githubusercontent.com/297400/177162706-32020eb0-e2d8-4b6f-90f7-2ec8ae543f8d.png">

