### PR TITLE
Fix navbar scenario test

### DIFF
--- a/plone-5/instance/custom.cfg
+++ b/plone-5/instance/custom.cfg
@@ -41,4 +41,4 @@ post-extras =
 eea.api.dataconnector = 2.3
 
 [sources]
-ukstats.ccv2.theme = git https://github.com/GSS-Cogs/ukstats.ccv2.theme.git branch=main
+ukstats.ccv2.theme = git https://github.com/GSS-Cogs/ukstats.ccv2.theme.git rev=v0.4

--- a/tests/climate-change-v2/features/overview.feature
+++ b/tests/climate-change-v2/features/overview.feature
@@ -10,14 +10,12 @@ Feature: Overview
     Then I expect the element "#page-document" is visible
     And I take a screenshot
 
-# TODO: Reimplement this test once we investigate Jenkins differences.
-# If I implement this manually using the browser console, it should show a pass.
-#   Scenario: Navigation bar menus
-#     When I wait for xpath "//span[contains(text(), 'Dashboards')]" to be visible
-#     And I click the "span" element containing "Dashboards"
-#     And I wait for xpath "//p[contains(text(), 'Dashboards about the different indicators of climate change')]" to be visible
-#     And I wait for xpath "//a[contains(text(), 'Emissions')]" to be visible
-#     Then I take a screenshot
+   Scenario: Navigation bar menus
+     When I wait for xpath "//span[contains(text(), 'Dashboards')]" to be visible
+     And I click the "span" element containing "Dashboards"
+     And I wait for xpath "//p[contains(text(), 'Dashboards about the different indicators of climate change')]" to be visible
+     And I wait for xpath "//a[contains(text(), 'Emissions')]" to be visible
+     Then I take a screenshot
 
   Scenario: Related links
     When I wait for xpath "//*[contains(text(), 'Related Links')]" to be visible

--- a/tests/climate-change-v2/run.sh
+++ b/tests/climate-change-v2/run.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -eo pipefail
-
 echo -n "Waiting for plone..."
 timeout 120 sh -c "until nc -z -w 1 plone 8080; do sleep 1; echo -n '.'; done"
 echo -ne "ready.\nWaiting for volto..."
@@ -11,6 +9,6 @@ echo "ready."
 TESTDIR=$PWD
 cd /home/node/app
 export SCREENSHOT_PATH=$TESTDIR/screenshots/
-NODE_PATH=/home/node/app/node_modules ./node_modules/.bin/cucumber-js --require "../**/{cucumber-puppeteer,cucumber-puppeteer-axe}/features/**/*.js" --require "$TESTDIR/features/**/*.js" --world-parameters "{\"executablePath\":\"/usr/bin/chromium-browser\", \"dumpio\": true}" $TESTDIR/features --format=json:$TESTDIR/test-results.json
+NODE_PATH=/home/node/app/node_modules ./node_modules/.bin/cucumber-js --require "../**/{cucumber-puppeteer,cucumber-puppeteer-axe}/features/**/*.js" --require "$TESTDIR/features/**/*.js" --world-parameters "{\"executablePath\":\"/usr/bin/chromium-browser\", \"dumpio\": true, \"defaultViewport\": {\"width\": 1512, \"height\": 982}}" $TESTDIR/features --format=json:$TESTDIR/test-results.json
 cd $TESTDIR
 NODE_PATH=/home/node/app/node_modules node toHTML.js


### PR DESCRIPTION
Pin test fixture default content to v0.4
Re-instate skipped test scenario.
Set viewport size to 1512 x 982.
Continue script if cucumber-js gives error.

Closes #465 .