### PR TITLE
Issue 392/hero header phase banner

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/CcHeroHeader/CcHeroHeaderView.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcHeroHeader/CcHeroHeaderView.jsx
@@ -38,7 +38,10 @@ export const CcHeroHeaderView = (props) => {
   }, [content]);
 
   return (
-    <CcMasthead className="app-masthead--bottom-overlap">
+    <CcMasthead
+      className="app-masthead--bottom-overlap"
+      shouldDisplayPhaseBanner={true}
+    >
       <div className="govuk-grid-column-two-thirds-from-desktop">
         <Tag className="govuk-tag--grey app-masthead__tag">NEW ARTICLE</Tag>
         <h1 className="govuk-heading-xl app-masthead__title">{title}</h1>

--- a/volto/src/addons/volto-climatechange-elements/src/components/CcMasthead/CcMasthead.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcMasthead/CcMasthead.jsx
@@ -1,11 +1,29 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { PhaseBanner } from 'govuk-react-jsx';
 
-export const CcMasthead = ({ children, className }) => (
-    <div className={`app-masthead ${className || ''}`}>
-        <div className="app-width-container">
-            <div className="govuk-grid-row">
-                {children}
-            </div>
+export const CcMasthead = ({
+  children,
+  className,
+  shouldDisplayPhaseBanner,
+}) => (
+  <div className={`app-masthead ${className || ''}`}>
+    <div className="app-width-container">
+      {shouldDisplayPhaseBanner ? (
+        <div>
+          <PhaseBanner
+            className="cc-phasebanner-masthead"
+            tag={{
+              children: 'beta',
+            }}
+          >
+            This is a new service your{' '}
+            <Link to="https://example.com">feedback</Link> will help us improve
+            it.
+          </PhaseBanner>
         </div>
+      ) : null}
+      <div className="govuk-grid-row">{children}</div>
     </div>
+  </div>
 );

--- a/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/CcHeroHeader/_ccHeroHeader.scss
+++ b/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/CcHeroHeader/_ccHeroHeader.scss
@@ -1,18 +1,18 @@
 // Adapted from https://github.com/alphagov/govuk-design-system/blob/main/src/stylesheets/components/_masthead.scss
 
 .app-masthead__tag {
-    color: govuk-colour("blue");
-    @include govuk-responsive-margin(2, "bottom");
+  color: govuk-colour('blue');
+  @include govuk-responsive-margin(2, 'bottom');
 }
 
 .app-masthead__title {
-    color: govuk-colour("white");
-    @include govuk-responsive-margin(6, "bottom");
+  color: govuk-colour('white');
+  @include govuk-responsive-margin(6, 'bottom');
 }
 
 .app-masthead__description {
-    @include govuk-font(24);
-    @include govuk-responsive-margin(6, "bottom");
+  @include govuk-font(24);
+  @include govuk-responsive-margin(6, 'bottom');
 }
 
 .app-masthead__start,
@@ -20,18 +20,35 @@
 .app-masthead__start:visited,
 .app-masthead__start:active,
 .app-masthead__start:hover {
-    color: govuk-colour("blue");
+  color: govuk-colour('blue');
 }
 
 .app-masthead__image {
-    display: none;
+  display: none;
 
-    @include govuk-not-ie8 {
-        @include govuk-media-query($from: desktop) {
-            display: block;
-            width: 100%;
-            margin-top: govuk-spacing(-6);
-            margin-bottom: govuk-spacing(-6);
-        }
+  @include govuk-not-ie8 {
+    @include govuk-media-query($from: desktop) {
+      display: block;
+      width: 100%;
+      margin-top: govuk-spacing(-6);
+      margin-bottom: govuk-spacing(-6);
     }
+  }
+}
+
+div.cc-phasebanner-masthead {
+  border-bottom: none;
+  margin-bottom: govuk-spacing(6);
+  strong.govuk-phase-banner__content__tag {
+    background: govuk-colour('light-grey');
+  }
+  strong.govuk-tag {
+    color: govuk-colour('blue');
+  }
+  p.govuk-phase-banner__content {
+    color: govuk-colour('white');
+  }
+  a {
+    color: govuk-colour('white');
+  }
 }

--- a/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/CcMasthead/_ccMasthead.scss
+++ b/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/CcMasthead/_ccMasthead.scss
@@ -1,16 +1,15 @@
 // Adapted from https://github.com/alphagov/govuk-design-system/blob/main/src/stylesheets/components/_masthead.scss
 
 .app-masthead {
-    @include govuk-responsive-padding(6, "top");
-    @include govuk-responsive-padding(6, "bottom");
-    color: govuk-colour("white");
-    background-color: govuk-colour("blue");
+  @include govuk-responsive-padding(6, 'bottom');
+  color: govuk-colour('white');
+  background-color: govuk-colour('blue');
 
-    &--article {
-        background-color: govuk-colour('light-grey');
-      }
+  &--article {
+    background-color: govuk-colour('light-grey');
+  }
 
-    &--bottom-overlap {
-        margin-bottom: govuk-spacing(-6);
-    }
+  &--bottom-overlap {
+    margin-bottom: govuk-spacing(-6);
+  }
 }


### PR DESCRIPTION
Phase banner added to hero header.
This closes #392 

<img width="1440" alt="Screenshot 2022-07-12 at 19 48 03" src="https://user-images.githubusercontent.com/297400/178571444-6d4e3f3a-d301-4aa1-82ce-6a1fb748e5df.png">

Feedback email requires updated (by a separate issue).