### PR TITLE
Use seamless mode in testing

### DIFF
--- a/tests/climate-change-v2/docker-compose.yml
+++ b/tests/climate-change-v2/docker-compose.yml
@@ -10,10 +10,7 @@ services:
   volto:
     build:
       context: ../../volto
-      args:
-        ADDONS: "@eeacms/volto-datablocks;@eeacms/volto-columns-block;volto-slate:asDefault;volto-govuk-theme;volto-chart-builder;volto-climatechange-elements"
     environment:
-      - RAZZLE_API_PATH=http://climate-change.data.gov.uk/api
       - NODE_ENV=production
     networks:
       - test_net

--- a/tests/climate-change-v2/proxy/default.conf
+++ b/tests/climate-change-v2/proxy/default.conf
@@ -8,12 +8,28 @@ upstream plone {
 server {
     server_name climate-change.data.gov.uk;
     listen 80 ;
-    location ~ /api($|/.*) {
-        rewrite ^/api($|/.*) /VirtualHostBase/http/climate-change.data.gov.uk:80/Plone/VirtualHostRoot/_vh_api$1 break;
-        proxy_pass http://plone;
+    location ~ /\+\+api\+\+($|/.*) {
+      rewrite ^/\+\+api\+\+($|/.*) /VirtualHostBase/http/climate-change.data.gov.uk/Plone/++api++/VirtualHostRoot/$1 break;
+      proxy_pass http://plone;
     }
 
     location ~ / {
-        proxy_pass http://volto;
+      location ~* \.(js|jsx|css|less|swf|eot|ttf|otf|woff|woff2)$ {
+          add_header Cache-Control "public";
+          expires +1y;
+          proxy_pass http://volto;
+      }
+      location ~* static.*\.(ico|jpg|jpeg|png|gif|svg)$ {
+          add_header Cache-Control "public";
+          expires +1y;
+          proxy_pass http://volto;
+      }
+
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+      # proxy_redirect http:// https://;
+      proxy_pass http://volto;
     }
 }


### PR DESCRIPTION
No need for RAZZLE_API_PATH or ADDONS (for testing).
Update nginx routing for ++api++.

This brings the tests in line with the way that beta2 is deployed and how we expect the release to be deployed.

Closes #512 