### PR TITLE
Workflow manager

### DIFF
--- a/plone-5/instance/custom.cfg
+++ b/plone-5/instance/custom.cfg
@@ -15,6 +15,7 @@ eggs += kitconcept.volto
         pas.plugins.authomatic
         ukstats.ccv2.theme
         ukstats.ccv2.content_types
+        plone.app.workflowmanager
 
 extensions +=
     mr.developer
@@ -42,3 +43,4 @@ eea.api.dataconnector = 2.3
 
 [sources]
 ukstats.ccv2.theme = git https://github.com/GSS-Cogs/ukstats.ccv2.theme.git rev=v0.5
+plone.app.workflowmanager = git https://github.com/plone/plone.app.workflowmanager.git branch=py3


### PR DESCRIPTION
Add workflow manager from branch py3, as current release works with python 2.7.

Note that this is a Plone only tool and is for design and development of workflow, so we may want to remove it from the release.