### PR TITLE
Fix styling issues with CcArticleListExt and related files

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/CcArticleHeader/CcArticleHeader.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcArticleHeader/CcArticleHeader.jsx
@@ -5,7 +5,7 @@ import { CcMasthead } from '../CcMasthead/CcMasthead';
 export const CcArticleHeader = ({ data }) => {
   return (
     <CcMasthead className="app-masthead--article">
-      <div className="cc-article-header app-width-container">
+      <div className="cc-article-header">
         <div className="govuk-!-padding-right-6">
           {data?.dashboard ? (
             <p className="govuk-caption-l">Dashboard</p>

--- a/volto/src/addons/volto-climatechange-elements/src/components/CcArticleList/CcArticleListExt.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcArticleList/CcArticleListExt.jsx
@@ -36,29 +36,27 @@ export const CcArticleListExt = (props) => {
   return (
     <div>
       <CcMasthead className="app-masthead--article cc-article-featured">
-        <div className="cc-article-header volto-width-container--wide">
-          <div className="govuk-grid-row">
-            <div className="govuk-!-padding-right-6">
-              <H4>{firstItemDate}</H4>
-              <h1 className="govuk-heading-xl govuk-!-margin-bottom-6">
-                {firstItem?.title}
-              </h1>
-              <p className="govuk-caption-m govuk-!-margin-bottom-6">
-                <span className="cc-article-header__date">
-                  Written by {firstItemCreators}
-                </span>
-              </p>
-              <p className="govuk-body-l">{firstItem?.description}</p>
+        <div className="cc-article-header">
+          <div className="govuk-!-padding-right-6">
+            <H4>{firstItemDate}</H4>
+            <h1 className="govuk-heading-xl govuk-!-margin-bottom-6">
+              {firstItem?.title}
+            </h1>
+            <p className="govuk-caption-m govuk-!-margin-bottom-6">
+              <span className="cc-article-header__date">
+                Written by {firstItemCreators}
+              </span>
+            </p>
+            <p className="govuk-body-l">{firstItem?.description}</p>
 
-              <H4>
-                <a
-                  href={firstItem?.['@id']?.replace('/api', '')}
-                  className="cc-article-list"
-                >
-                  Read article
-                </a>
-              </H4>
-            </div>
+            <H4>
+              <a
+                href={firstItem?.['@id']?.replace('/api', '')}
+                className="cc-article-list"
+              >
+                Read article
+              </a>
+            </H4>
           </div>
         </div>
       </CcMasthead>

--- a/volto/src/addons/volto-climatechange-elements/src/components/CcHeroHeader/CcHeroHeaderView.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcHeroHeader/CcHeroHeaderView.jsx
@@ -42,26 +42,28 @@ export const CcHeroHeaderView = (props) => {
       className="app-masthead--bottom-overlap"
       shouldDisplayPhaseBanner={true}
     >
-      <div className="govuk-grid-column-one-half app-masthead__grid-column">
-        <Tag className="govuk-tag--grey app-masthead__tag">NEW ARTICLE</Tag>
-        <h1 className="govuk-heading-xl app-masthead__title">{title}</h1>
-        <p className="app-masthead__description">{summary}</p>
-        <Button
-          isStartButton
-          className="govuk-button--secondary app-masthead__start"
-          href={articlePath}
-        >
-          Read article
-        </Button>
-      </div>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-one-half app-masthead__grid-column">
+          <Tag className="govuk-tag--grey app-masthead__tag">NEW ARTICLE</Tag>
+          <h1 className="govuk-heading-xl app-masthead__title">{title}</h1>
+          <p className="app-masthead__description">{summary}</p>
+          <Button
+            isStartButton
+            className="govuk-button--secondary app-masthead__start"
+            href={articlePath}
+          >
+            Read article
+          </Button>
+        </div>
 
-      <div className="govuk-grid-column-one-half app-masthead__grid-column">
-        <img
-          className="app-masthead__image"
-          src={earth}
-          alt=""
-          role="presentation"
-        />
+        <div className="govuk-grid-column-one-half app-masthead__grid-column">
+          <img
+            className="app-masthead__image"
+            src={earth}
+            alt=""
+            role="presentation"
+          />
+        </div>
       </div>
     </CcMasthead>
   );

--- a/volto/src/addons/volto-climatechange-elements/src/components/CcMasthead/CcMasthead.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcMasthead/CcMasthead.jsx
@@ -23,7 +23,7 @@ export const CcMasthead = ({
           </PhaseBanner>
         </div>
       ) : null}
-      <div className="govuk-grid-row app-masthead__grid-row">{children}</div>
+      <div className="app-masthead__grid-row">{children}</div>
     </div>
   </div>
 );


### PR DESCRIPTION
- These changes also fix issue #514
- Both issues were fixed by removing CSS styles that weren't required for the content to display correctly
- The issues were in part caused by the interaction between styles applied at different levels in the component hierarchy
- Removed volto-width-container--wide class from CcArticleListExt which was adding 30px margin on smaller screens, but not doing so on wider (e.g. desktop) screens.
- Removed entire div with govuk-grid-row class from CcArticleListExt which was acting to part compensate for the 30px margin with a -15px margin
- Removed govuk-grid-row class from the top level div of CcMasthead which was applying a -15px margin to part compensate the +30px on smaller viewports but caused the content move out of left alignment on larger screens
- Added govuk-grid-row to CcHeroHeaderView where it is required (to compensate for removing it from CcMasthead)
- Removed app-width-container class from the top level div of CcArticleHeader which was causing the dashboard header content to be centered


Closes #514

Closes #497