### PR TITLE
Issue 498/breadcrumbs

### DIFF
--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -65,6 +65,7 @@ class Breadcrumbs extends Component {
   render() {
     const { props } = this;
     const hasBreadcrumbItems = props.items && props.items.length >= 1;
+    const breadcrumbItems = props.items.slice(0, props.items.length - 1);
 
     return (
       <div className="cc-breadcrumbs">
@@ -86,7 +87,7 @@ class Breadcrumbs extends Component {
                   children: 'Home',
                   href: '/',
                 },
-                ...props.items.map((item, index, items) => ({
+                ...breadcrumbItems.map((item, index, items) => ({
                   children: item.title,
                   href: item.url,
                 })),

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -59,16 +59,6 @@ exports[`Breadcrumbs renders a breadcrumbs component 1`] = `
             Blog
           </a>
         </li>
-        <li
-          className="govuk-breadcrumbs__list-item"
-        >
-          <a
-            className="govuk-breadcrumbs__link"
-            href="/blog/my-first-blog"
-          >
-            My first blog
-          </a>
-        </li>
       </ol>
     </div>
   </div>


### PR DESCRIPTION
Removed current page link from breadcrumbs.
<img width="1437" alt="Screenshot 2022-08-09 at 08 48 50" src="https://user-images.githubusercontent.com/297400/183595365-daa36c49-915d-41fe-bca6-d881e8908a73.png">

<img width="1438" alt="Screenshot 2022-08-09 at 08 44 17" src="https://user-images.githubusercontent.com/297400/183595389-910126ce-a32e-419c-bdbc-0d3dc7dbdac5.png">


This closes #498 