### PR TITLE
Updated support link to mailto address

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/CcMasthead/CcMasthead.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcMasthead/CcMasthead.jsx
@@ -18,8 +18,16 @@ export const CcMasthead = ({
             }}
           >
             This is a new service your{' '}
-            <Link to="https://example.com">feedback</Link> will help us improve
-            it.
+            <Link
+              to="#"
+              onClick={(e) => {
+                window.location.href = "mailto:climate.change@ons.gov.uk";
+                e.preventDefault();
+              }}
+            >
+              feedback
+            </Link>{' '}
+            will help us improve it.
           </PhaseBanner>
         </div>
       ) : null}

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -77,8 +77,15 @@ class Breadcrumbs extends Component {
             }}
           >
             This is a new service your{' '}
-            <Link to="https://example.com">feedback</Link> will help us improve
-            it.
+            <Link
+              to="#"
+              onClick={(e) => {
+                window.location.href = "mailto:climate.change@ons.gov.uk";
+                e.preventDefault();
+              }}
+            >
+              feedback
+            </Link>{' '} will help us improve it.
           </PhaseBanner>
           {hasBreadcrumbItems && (
             <GovukBreadcrumbs

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -24,11 +24,12 @@ exports[`Breadcrumbs renders a breadcrumbs component 1`] = `
           This is a new service your
            
           <a
-            href="/https://example.com"
+            href="/"
             onClick={[Function]}
           >
             feedback
           </a>
+           
            will help us improve it.
         </span>
       </p>


### PR DESCRIPTION
- mailto:climate.change@ons.gov.uk
- changed in two components, CcMastHead & Breadcrumbs.jsx
- may need to refresh browser cache to test

closes #464 