### PR TITLE
issue-418/delete initial content for hero header

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/CcHeroHeader/CcHeroHeaderView.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcHeroHeader/CcHeroHeaderView.jsx
@@ -9,8 +9,8 @@ import { getRawContent } from '../../actions';
 import earth from './Earth.svg';
 
 export const CcHeroHeaderView = (props) => {
-  const [summary, setSummary] = useState(props.data.summary);
-  const [title, setTitle] = useState(props.data.title);
+  const [summary, setSummary] = useState('');
+  const [title, setTitle] = useState('');
 
   let articlePath = '#';
 
@@ -21,7 +21,6 @@ export const CcHeroHeaderView = (props) => {
   }
 
   const request = useSelector((state) => state.rawData?.[articlePath]);
-
   const content = request?.data || null;
 
   useEffect(() => {


### PR DESCRIPTION
- removed props.data.title from useState
- removed props.data.summary from useState

To. change the actual default text the props brings in initially, change it [here](https://github.com/GSS-Cogs/ukstats.ccv2.theme/blob/main/src/ukstats/ccv2/theme/content/front_blocks.json).

closes #418 