### PR TITLE
Change volto-slate config to impute GOVUK classes into HTML elements

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/config/volto-slate/SlateElements.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/config/volto-slate/SlateElements.jsx
@@ -1,0 +1,37 @@
+export const elements = {
+    default: ({ attributes, children }) => <p className="govuk-body" {...attributes}>{children}</p>,
+  
+    h1: ({ attributes, children }) => <h1 className="govuk-heading-xl" {...attributes}>{children}</h1>,
+    h2: ({ attributes, children }) => <h2 className="govuk-heading-l" {...attributes}>{children}</h2>,
+    h3: ({ attributes, children }) => <h3 className="govuk-heading-m" {...attributes}>{children}</h3>,
+    h4: ({ attributes, children }) => <h4 className="govuk-heading-s" {...attributes}>{children}</h4>,
+  
+    li: ({ attributes, children }) => <li {...attributes}>{children}</li>,
+    ol: ({ attributes, children }) => <ol className="govuk-list govuk-list--number" {...attributes}>{children}</ol>,
+    ul: ({ attributes, children }) => {
+      return <ul className="govuk-list govuk-list--bullet" {...attributes}>{children}</ul>;
+    },
+  
+    div: ({ attributes, children }) => <div {...attributes}>{children}</div>,
+    p: ({ attributes, children }) => {
+      return <p className="govuk-body" {...attributes}>{children}</p>;
+    },
+  
+    // While usual slate editor consider these to be Leafs, we treat them as
+    // inline elements because they can sometimes contain elements (ex:
+    // <b><a/></b>
+    em: ({ children }) => <em>{children}</em>,
+    i: ({ children }) => <i>{children}</i>,
+    b: ({ children }) => {
+      return <b className="govuk-typography-weight-bold">{children}</b>;
+    },
+    strong: ({ children }) => {
+      return <strong className="govuk-typography-weight-bold">{children}</strong>;
+    },
+    u: ({ children }) => <u>{children}</u>,
+    s: ({ children }) => <del>{children}</del>,
+    del: ({ children }) => <del>{children}</del>,
+    sub: ({ children }) => <sub>{children}</sub>,
+    sup: ({ children }) => <sup>{children}</sup>,
+    code: ({ children }) => <code>{children}</code>
+  };

--- a/volto/src/addons/volto-climatechange-elements/src/config/volto-slate/index.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/config/volto-slate/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { elements } from './SlateElements';
+import TitleBlockView from 'volto-slate/blocks/Title/TitleBlockView';
+import TitleBlockEdit from 'volto-slate/blocks/Title/TitleBlockEdit';
+
+export default (config) => {
+
+// https://github.com/eea/volto-slate/blob/master/src/editor/config.jsx
+// Customise volto-slate config to include govuk-classes within HTML tags.
+  config.settings.slate.elements = {
+    ...config.settings.slate.elements,
+    ...elements
+  };
+
+// https://github.com/eea/volto-slate/blob/master/src/blocks/Title/index.js
+// The title of a document has its own special widget which is used for rendering.
+// Component shadowing wasnt working for whatever reason, so we make changes here.
+// The widget set a class of "firstDocumentHeading" as opposed to inheriting the 
+// "govuk-heading-xl" class from <h1> tags.
+
+  const className = 'govuk-heading-xl';
+  const formFieldName = 'title';
+
+  config.blocks.blocksConfig.title.view = (props) => (
+    <TitleBlockView
+      {...props}
+      className={className}
+      formFieldName={formFieldName}
+    />
+  );
+  config.blocks.blocksConfig.title.edit = (props) => (
+    <TitleBlockEdit
+      {...props}
+      className={className}
+      formFieldName={formFieldName}
+    />
+  );
+
+  return config;
+};

--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto-slate/editor/plugins/Link/render.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto-slate/editor/plugins/Link/render.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { UniversalLink } from '@plone/volto/components';
+import { withHashLink } from 'volto-slate/hooks';
+import 'volto-slate/editor/plugins/Link/styles.less';
+
+export const LinkElement = withHashLink(
+  ({ attributes, children, element, mode, setHashLink }) => {
+    // TODO: handle title on internal links
+    let url = element.url;
+    const { link } = element.data || {};
+
+    const internal_link = link?.internal?.internal_link?.[0]?.['@id'];
+    const external_link = link?.external?.external_link;
+    const email = link?.email;
+    const internal_hash = link?.hash?.internal_hash?.[0]?.['id'];
+
+    const href = internal_hash
+      ? `#${internal_hash}`
+      : email
+      ? `mailto:${email.email_address}${
+          email.email_subject ? `?subject=${email.email_subject}` : ''
+        }`
+      : external_link || internal_link || url;
+
+    const { title } = element?.data || {};
+
+    return mode === 'view' ? (
+      <>
+        {internal_hash ? (
+          <a
+            href={`#${internal_hash}`}
+            className ="govuk-link"
+            title={title}
+            onClick={(event) => {
+              event.preventDefault();
+              setHashLink(internal_hash, link.hash.internal_hash[0]);
+            }}
+          >
+            {children}
+          </a>
+        ) : (
+          <UniversalLink
+            href={href || '#'}
+            className ="govuk-link"
+            openLinkInNewTab={link?.external?.target === '_blank'}
+            title={title}
+          >
+            {children}
+          </UniversalLink>
+        )}
+      </>
+    ) : (
+      <span {...attributes} className="slate-editor-link govuk-link">
+        {children}
+      </span>
+    );
+  },
+);

--- a/volto/src/addons/volto-climatechange-elements/src/index.js
+++ b/volto/src/addons/volto-climatechange-elements/src/index.js
@@ -13,6 +13,7 @@ import { CcArticleListExt } from './components/CcArticleList/CcArticleListExt';
 import { relatedItemsData, rawData, folderishContent } from './reducers';
 
 import '../theme/main.scss';
+import customiseSlateConfig from './config/volto-slate/index';
 
 const applyConfig = (config) => {
   config.blocks.blocksConfig.dashboardTile = {
@@ -91,6 +92,8 @@ const applyConfig = (config) => {
   config.addonReducers.relatedItemsData = relatedItemsData;
   config.addonReducers.rawData = rawData;
   config.addonReducers.folderishContent = folderishContent;
+
+  config = customiseSlateConfig(config);
 
   return config;
 };


### PR DESCRIPTION
This commit alters the `volto-slate` config to inject the `govuk-frontend` classes into the content's HTML tags. So `<p>` becomes `<p class="govuk-body">` etc.

The largest difference is in the "about" page currently in the CC site, which is currently using `<h4>` tags to try and get "normal" text to display properly. These could be changed to regular text following the addition of the `govuk-frontend` classes.

![image](https://user-images.githubusercontent.com/74777313/185441700-c7c32e93-9636-43d1-8279-559d14d44785.png)
