### PR TITLE
Change article list styling to extend govuk styles

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/CcArticleList/_ccArticleList.scss
+++ b/volto/src/addons/volto-climatechange-elements/theme/ClimateChange/CcArticleList/_ccArticleList.scss
@@ -1,10 +1,10 @@
 .cc-article-list {
-  text-decoration: none;
+  @extend %govuk-heading-m;
   color: govuk-colour('blue');
 }
 
 .cc-article-list-description {
-  color: govuk-colour('dark-grey');
+  @extend %govuk-body-m;
 }
 
 .cc-article-preview {


### PR DESCRIPTION
Noticed the article list styling differing slightly from the figma design, and the header font I think was Arial.

Before:

<img width="889" alt="image" src="https://user-images.githubusercontent.com/74777313/186682947-6440480b-dd0e-4f2d-bf6f-2d906f530c98.png">

After: 

<img width="889" alt="image" src="https://user-images.githubusercontent.com/74777313/186683016-e056fabb-20cf-4847-97de-b0df9d5b4764.png">
