### PR TITLE
Tag docker-compose built images with Git short SHA

### DIFF
--- a/deploy/.env
+++ b/deploy/.env
@@ -1,2 +1,3 @@
 # preserve the project name from when this was deployed from the project root.
 COMPOSE_PROJECT_NAME="dd-cms"
+GIT_COMMIT_SHORT="local-dev"

--- a/deploy/deployment-jenkinsfile
+++ b/deploy/deployment-jenkinsfile
@@ -2,6 +2,12 @@ pipeline {
     agent any
     stages {
         stage('build') {
+            environment {
+                GIT_COMMIT_SHORT = sh(
+                        script: "printf \$(git rev-parse --short ${GIT_COMMIT})",
+                        returnStdout: true
+                )
+            }
             steps {
                 dir('deploy') {
                     sh "docker-compose build plone-cc2 volto-v2"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
     plone-vawag:
+        image: plone-vawag:${GIT_COMMIT_SHORT}
         build:
             context: ../plone-5
         volumes:
@@ -11,6 +12,7 @@ services:
         restart: always
 
     plone-cc2:
+        image: plone-cc2:${GIT_COMMIT_SHORT}
         build:
             context: ../plone-5
         volumes:
@@ -20,6 +22,7 @@ services:
         restart: always
 
     volto-vawag:
+        image: volto-vawag:${GIT_COMMIT_SHORT}
         build:
             context: ../volto
             args:
@@ -37,6 +40,7 @@ services:
         restart: always
 
     volto-v2:
+        image: volto-v2:${GIT_COMMIT_SHORT}
         build:
             context: ../volto
             args:


### PR DESCRIPTION
Tag images as part of docker-compose build.
Use git short SHA hash.
Default to local-dev if not set.