### PR TITLE
Hotjar analytics fix

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -44,8 +44,8 @@ services:
         environment:
             - RAZZLE_API_PATH=https://staging.climate-change.data.gov.uk/api
             - RAZZLE_GA4_CODE=G-Y84VSLC1LC
-            - HOTJAR_ID=3118262
-            - HOTJAR_VERSION=6
+            - RAZZLE_RUNTIME_HOTJAR_ID=3118262
+            - RAZZLE_RUNTIME_HOTJAR_VERSION=6
             - NODE_ENV=production
             - VIRTUAL_HOST=staging.climate-change.data.gov.uk
             - VIRTUAL_PORT=3000

--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { SuperNavigationHeader } from '../../../../../components/CcSuperNavigationHeader/CcSuperNavigationHeader';
 import { getSiteTitle } from '../../../../../actions';
 import { useGoogleAnalytics } from 'volto-google-analytics';
+import { hotjar } from 'react-hotjar';
 
 const headerConfigDefault = {
   logo_link_title: 'Go to the GOV.UK homepage',
@@ -51,6 +52,10 @@ const Header = (props) => {
 
   const dispatch = useDispatch();
   useEffect(() => {
+    hotjar.initialize(
+      process.env.RAZZLE_RUNTIME_HOTJAR_ID,
+      process.env.RAZZLE_RUNTIME_HOTJAR_VERSION,
+    );
     dispatch(getSiteTitle());
   }, []);
 


### PR DESCRIPTION
This closes #598 

RAZZLE_RUN_TIME_* env variables used to set hotjar acc details