### PR TITLE
vawg.gss-data.org.uk

### DIFF
--- a/deploy/deployment-jenkinsfile
+++ b/deploy/deployment-jenkinsfile
@@ -10,14 +10,14 @@ pipeline {
             }
             steps {
                 dir('deploy') {
-                    sh "docker-compose build plone-cc2 volto-v2"
+                    sh "docker-compose build plone-cc2 volto-v2 plone-vawag volto-vawag"
                 }
             }
         }
         stage('run') {
             steps {
                 dir('deploy') {
-                      sh "docker-compose up -d plone-cc2 volto-v2"
+                      sh "docker-compose up -d plone-cc2 volto-v2 plone-vawag volto-vawag"
                 }
             }
         }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,11 +28,10 @@ services:
             args:
                 ADDONS: "@eeacms/volto-datablocks;@eeacms/volto-columns-block;volto-slate:asDefault;volto-authomatic;volto-govuk-theme;volto-chart-builder"
         environment:
-            - RAZZLE_API_PATH=https://vawg.ukstats.dev/api
             - NODE_ENV=production
-            - VIRTUAL_HOST=vawg.ukstats.dev
+            - VIRTUAL_HOST=vawg.ukstats.dev,vawg.gss-data.org.uk
             - VIRTUAL_PORT=3000
-            - LETSENCRYPT_HOST=vawg.ukstats.dev
+            - LETSENCRYPT_HOST=vawg.ukstats.dev,vawg.gss-data.org.uk
         command: "yarn start:prod"
         init: true
         networks:

--- a/volto/vhosts.d/vawg.gss-data.org.uk
+++ b/volto/vhosts.d/vawg.gss-data.org.uk
@@ -1,0 +1,5 @@
+location ~ /\+\+api\+\+($|/.*) {
+      rewrite ^/\+\+api\+\+($|/.*) /VirtualHostBase/https/vawg.gss-data.org.uk:443/Plone/++api++/VirtualHostRoot/$1 break;
+      proxy_pass http://plone-vawag:8080;
+}
+client_max_body_size 100m;

--- a/volto/vhosts.d/vawg.ukstats.dev
+++ b/volto/vhosts.d/vawg.ukstats.dev
@@ -1,0 +1,5 @@
+location ~ /\+\+api\+\+($|/.*) {
+      rewrite ^/\+\+api\+\+($|/.*) /VirtualHostBase/https/vawg.ukstats.dev:443/Plone/++api++/VirtualHostRoot/$1 break;
+      proxy_pass http://plone-vawag:8080;
+}
+client_max_body_size 100m;


### PR DESCRIPTION
* Add virtual host & certbot for vawg.gss-data.org.uk.
* Add nginx config, using new style `/++api++` so we don't need RAZZLE_API_PATH and can use the same Volto front end for multiple hosts.
* Build and deploy on merge to main