### PR TITLE
feedback link now shows current link

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/CcPhaseBannerWrapper/CcPhaseBannerWrapper.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcPhaseBannerWrapper/CcPhaseBannerWrapper.jsx
@@ -43,17 +43,14 @@ export const CcPhaseBannerWrapper = ({ className }) => {
         }}
       >
         This is a new service your{' '}
-        <Link
-          to="#"
-          onClick={(e) => {
-            //'mailto:climate.change@ons.gov.uk';
-            window.open(phaseBannerLink, '_blank', 'noopener,noreferrer');
-            e.preventDefault();
-          }}
+        <a
+          href={phaseBannerLink}
           style={{ textDecorationLine: 'underline' }}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           feedback
-        </Link>{' '}
+        </a>{' '}
         will help us improve it.
       </PhaseBanner>
     </div>

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/Breadcrumbs/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -25,13 +25,14 @@ exports[`Breadcrumbs renders a breadcrumbs component 1`] = `
             This is a new service your
              
             <a
-              href="/"
-              onClick={[Function]}
+              href=""
+              rel="noopener noreferrer"
               style={
                 Object {
                   "textDecorationLine": "underline",
                 }
               }
+              target="_blank"
             >
               feedback
             </a>


### PR DESCRIPTION
 - when highlighted was showing link to current page
 - now shows current feedback link

relates to ticket [#21](https://app.zenhub.com/workspaces/cogs-dd-cms-61e83b63053eb70011d37b4f/issues/gss-cogs/ukstats.ccv2.theme/21)