### PR TITLE
get url from @id

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
@@ -80,7 +80,7 @@ const Header = (props) => {
   dashBoardItems.map((item) => {
     menu_contents.push({
       label: item.title,
-      href: `${item.url}`,
+      href: `${item['@id']}`,
       description: item.description,
     });
   });


### PR DESCRIPTION
With the fix to get dashboard descriptions, listDashboardItems was used instead of listNavigation. listDashboardItems doesn't contain the urls but the @id for them is the url, so that has be used as a quick fix.

listNavigation doesn't contain the descriptions for the articles so it might be worth it, in the future, to combine the two to get everything we need.
