### PR TITLE
Issue 637/download figure as image

### DIFF
--- a/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
@@ -30,27 +30,28 @@ const convertToAlphaNumericSnakeCase = (str) => {
     .replace(/[^a-zA-Z0-9-]/g, '');
 };
 
-function toggleDisplay(className, displayState) {
-  var elements = document.getElementsByClassName(className);
-
+function toggleDisplay(className, displayState, node) {
+  let elements = node.querySelectorAll('.' + className);
   for (var i = 0; i < elements.length; i++) {
     elements[i].style.display = displayState;
   }
 }
 
 const FigureViewComponent = ({ content, location }) => {
-  const [loadSecondFigure, setLoadSecondFigure] = useState(false);
+  const [renderFigureBlockDownload, setRenderFigureBlockDownload] = useState(
+    false,
+  );
 
   useEffect(() => {
-    if (loadSecondFigure) {
+    if (renderFigureBlockDownload) {
       onDownloadFigureClick(id);
     }
-  }, [loadSecondFigure]);
+  }, [renderFigureBlockDownload]);
 
-  const FigureBlock = (compId) => {
-    const style = compId.id === '' ? '' : `figure ${customClasses}`;
+  const FigureBlock = ({ id }) => {
+    const style = id === undefined ? '' : `figure ${customClasses}`;
     return (
-      <div id={compId.id} className={style}>
+      <div id={id} className={style}>
         {map(content[blocksLayoutFieldname].items, (block) => {
           const isTitleBlock =
             content[blocksFieldname]?.[block]?.['@type'] === 'title';
@@ -75,6 +76,21 @@ const FigureViewComponent = ({ content, location }) => {
     );
   };
 
+  const FigureBlockDownload = ({ id }) => {
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          opacity: 0,
+          pointerEvents: 'none',
+          width: '1280px',
+        }}
+      >
+        <FigureBlock id={id} />
+      </div>
+    );
+  };
+
   const blocksFieldname = getBlocksFieldname(content);
   const blocksLayoutFieldname = getBlocksLayoutFieldname(content);
   const customClasses = classes([
@@ -89,14 +105,10 @@ const FigureViewComponent = ({ content, location }) => {
     // temporarily add 32px padding either side of the figure to give the downloaded image space around it
     node.classList.add('pad-for-download');
     // hide any elements that should not be included in the image (e.g. the Download button)
-    toggleDisplay('non-content', 'none');
+    toggleDisplay('non-content', 'none', node);
     domtoimage.toBlob(node).then(function (blob) {
-      // now we have the blob, show the hidden elements again
-      toggleDisplay('non-content', 'block');
-      // and remove the extra padding
-      node.classList.remove('pad-for-download');
       saveAs(blob, `${filename}.png`);
-      setLoadSecondFigure(false);
+      setRenderFigureBlockDownload(false);
     });
   };
 
@@ -107,27 +119,16 @@ const FigureViewComponent = ({ content, location }) => {
   return hasBlocksData(content) ? (
     <>
       <div className={`figure ${customClasses}`}>
-        <FigureBlock id="" />
+        <FigureBlock />
         <button
           className="govuk-button govuk-button--secondary non-content"
           data-module="govuk-button"
           style={{ marginTop: '32px', marginBottom: '32px' }}
-          onClick={() => setLoadSecondFigure(true)}
+          onClick={() => setRenderFigureBlockDownload(true)}
         >
           Download Figure
         </button>
-        {loadSecondFigure && (
-          <div
-            style={{
-              position: 'absolute',
-              opacity: 0,
-              pointerEvents: 'none',
-              width: '1280px',
-            }}
-          >
-            <FigureBlock id={id} />
-          </div>
-        )}
+        {renderFigureBlockDownload && <FigureBlockDownload id={id} />}
       </div>
     </>
   ) : (

--- a/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
@@ -117,7 +117,12 @@ const FigureViewComponent = ({ content, location }) => {
         </button>
         {loadSecondFigure && (
           <div
-            style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}
+            style={{
+              position: 'absolute',
+              opacity: 0,
+              pointerEvents: 'none',
+              width: '1280px',
+            }}
           >
             <FigureBlock id={id} />
           </div>

--- a/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
@@ -97,7 +97,7 @@ const FigureViewComponent = ({ content, location }) => {
           data-module="govuk-button"
           onClick={(event) => onPublishClick(event, id)}
         >
-          Download
+          Download Figure
         </button>
       </div>
     </>

--- a/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
@@ -6,8 +6,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
-
 import { map } from 'lodash';
+import domtoimage from 'dom-to-image';
+import { saveAs } from 'file-saver';
+import { v4 as uuidv4 } from 'uuid';
 import config from '@plone/volto/registry';
 
 import {
@@ -18,15 +20,27 @@ import {
 } from '@plone/volto/helpers';
 
 import { classes } from '../../utils';
-
 import { FigureTitleView } from './FigureTitleView';
-
 import './figure.scss';
+
+const convertToAlphaNumericSnakeCase = (str) => {
+  return str
+    .replace(/\s+/g, '-')
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9-]/g, '');
+};
+
+function toggleDisplay(className, displayState) {
+  var elements = document.getElementsByClassName(className);
+
+  for (var i = 0; i < elements.length; i++) {
+    elements[i].style.display = displayState;
+  }
+}
 
 const FigureViewComponent = ({ content, location }) => {
   const blocksFieldname = getBlocksFieldname(content);
   const blocksLayoutFieldname = getBlocksLayoutFieldname(content);
-
   const customClasses = classes([
     {
       val: content.Background ? content.Background.title : null,
@@ -34,29 +48,59 @@ const FigureViewComponent = ({ content, location }) => {
     },
   ]);
 
+  const onPublishClick = (event, id) => {
+    const node = document.getElementById(id);
+    // temporarily add 32px padding either side of the figure to give the downloaded image space around it
+    node.classList.add('pad-for-download');
+    // hide any elements that should not be included in the image (e.g. the Download button)
+    toggleDisplay('non-content', 'none');
+
+    domtoimage.toBlob(node).then(function (blob) {
+      // now we have the blob, show the hidden elements again
+      toggleDisplay('non-content', 'block');
+      // and remove the extra padding
+      node.classList.remove('pad-for-download');
+      saveAs(blob, `${filename}.png`);
+    });
+  };
+
+  const id = uuidv4();
+
+  const filename = convertToAlphaNumericSnakeCase(content.title);
+
   return hasBlocksData(content) ? (
-    <div className={`figure ${customClasses}`}>
-      {map(content[blocksLayoutFieldname].items, (block) => {
-        const isTitleBlock =
-          content[blocksFieldname]?.[block]?.['@type'] === 'title';
+    <>
+      <div id={id} className={`figure ${customClasses}`}>
+        {map(content[blocksLayoutFieldname].items, (block) => {
+          const isTitleBlock =
+            content[blocksFieldname]?.[block]?.['@type'] === 'title';
 
-        let Block = isTitleBlock
-          ? (props) => <FigureTitleView {...props} />
-          : config.blocks.blocksConfig[
-              content[blocksFieldname]?.[block]?.['@type']
-            ]?.['view'] || null;
+          let Block = isTitleBlock
+            ? (props) => <FigureTitleView {...props} />
+            : config.blocks.blocksConfig[
+                content[blocksFieldname]?.[block]?.['@type']
+              ]?.['view'] || null;
 
-        return Block !== null ? (
-          <Block
-            key={block}
-            id={block}
-            properties={content}
-            data={content[blocksFieldname][block]}
-            path={getBaseUrl(location?.pathname || '')}
-          />
-        ) : null;
-      })}
-    </div>
+          return Block !== null ? (
+            <Block
+              key={block}
+              id={block}
+              properties={content}
+              data={content[blocksFieldname][block]}
+              path={getBaseUrl(location?.pathname || '')}
+            />
+          ) : null;
+        })}
+
+        <button
+          className="govuk-button govuk-button--secondary non-content"
+          data-module="govuk-button"
+          onClick={(event) => onPublishClick(event, id)}
+        >
+          Download
+        </button>
+      </div>
+    </>
   ) : (
     <div>Add Figure Block</div>
   );

--- a/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
@@ -111,6 +111,7 @@ const FigureViewComponent = ({ content, location }) => {
         <button
           className="govuk-button govuk-button--secondary non-content"
           data-module="govuk-button"
+          style={{ marginTop: '32px', marginBottom: '32px' }}
           onClick={() => setLoadSecondFigure(true)}
         >
           Download Figure

--- a/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/FigureView.jsx
@@ -43,7 +43,7 @@ const FigureViewComponent = ({ content, location }) => {
 
   useEffect(() => {
     if (loadSecondFigure) {
-      onPublishClick(id);
+      onDownloadFigureClick(id);
     }
   }, [loadSecondFigure]);
 
@@ -84,7 +84,7 @@ const FigureViewComponent = ({ content, location }) => {
     },
   ]);
 
-  const onPublishClick = (id) => {
+  const onDownloadFigureClick = (id) => {
     const node = document.getElementById(id);
     // temporarily add 32px padding either side of the figure to give the downloaded image space around it
     node.classList.add('pad-for-download');

--- a/volto/src/addons/volto-chart-builder/src/components/Figure/figure.scss
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/figure.scss
@@ -1,12 +1,12 @@
 .pad-for-download {
-  padding-left: 32px;
-  padding-right: 32px;
+  padding: 32px;
   width: calc(100% + 64px);
+  margin: 0px !important;
 }
 
 .figure {
-  padding-bottom: 32px;
-  padding-top: 32px;
+  margin-bottom: 32px;
+  margin-top: 32px;
   margin-left: 0;
   background-color: #fff;
 
@@ -41,7 +41,6 @@
   }
 
   &--bg-white-smoke {
-    padding-bottom: 32px;
     border-bottom: 1px solid #505a5f;
   }
 }

--- a/volto/src/addons/volto-chart-builder/src/components/Figure/figure.scss
+++ b/volto/src/addons/volto-chart-builder/src/components/Figure/figure.scss
@@ -1,8 +1,14 @@
+.pad-for-download {
+  padding-left: 32px;
+  padding-right: 32px;
+  width: calc(100% + 64px);
+}
+
 .figure {
-  max-width: 1280px;
-  margin-bottom: 32px;
-  margin-top: 32px;
+  padding-bottom: 32px;
+  padding-top: 32px;
   margin-left: 0;
+  background-color: #fff;
 
   &__text,
   p {


### PR DESCRIPTION
- Use the `dom2image` lib to convert the div containing the figure to blob
- Then save the blob as a PNG file
- Give each figure a unique ID using `uuidv4` 
- Use the page title to generate the filename (applying snake-case and removing non alphanumeric chars)
- Momentarily hide any 'non content' elements from the figure block (e.g. the download button) whilst capturing the content
- Momentarily add `32px` padding either side of the figure to give the downloaded image better presentation
- Set the figure background as white so that the downloaded image doesn't display on a transparent background
- GOV UK styled download button

Closes #637