### PR TITLE
Fix issue with tests not being picked up in volto-chart-builder:

### DIFF
--- a/volto/package.json
+++ b/volto/package.json
@@ -77,7 +77,8 @@
     ],
     "roots": [
       "<rootDir>/src/addons/volto-climatechange-elements/",
-      "<rootDir>/src/addons/volto-govuk-theme/"
+      "<rootDir>/src/addons/volto-govuk-theme/",
+      "<rootDir>/src/addons/volto-chart-builder/"
     ]
   },
   "prettier": {


### PR DESCRIPTION
- Added src/addons/volto-chart-builder to roots in package.json


Closes #767 