### PR TITLE
revert to rm over git clean

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,7 @@ pipeline {
                     */
                     sh "(test -d ${env.WORKSPACE}/volto/node_modules && rm -rf ${env.WORKSPACE}/volto/node_modules) || true"
                     sh "(test -f ${env.WORKSPACE}/volto/node_modules && rm -f ${env.WORKSPACE}/volto/node_modules) || true"
-                    /* this is a safer version of the git clean, but in Jenkins we have various
-                       "dirty" workspaces from before the caching attempts.
-                        so leave the git clean in for a bit, and when this is merged, after a while,
-                        go back to this one. */
-                    /* sh "find ${env.WORKSPACE}/volto/src/addons -type l -maxdepth 1 -exec rm \\{\\} \\; " */
-                    sh "git clean -f ${env.WORKSPACE}/volto/src/addons"
+                    sh "find ${env.WORKSPACE}/volto/src/addons -type l -maxdepth 1 -exec rm \\{\\} \\; "
                     sh "ln -s /app/node_modules ${env.WORKSPACE}/volto/"
                     sh "for n in \$(find /app/src/addons -type d -mindepth 1 -maxdepth 1); do ln -sf \$n ${env.WORKSPACE}/volto/src/addons/\$(basename \$n); done;"
                     sh "yarn test-ci"


### PR DESCRIPTION
use Alexs older method of clearing "dirty" files as git is killing the pipelines with permissions errors.