### PR TITLE
changed 'About the Portal' to 'About'

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
@@ -24,7 +24,7 @@ const headerConfigDefault = {
       menu_contents: [],
       footer_links: [
         {
-          label: 'About the portal',
+          label: 'About',
           href: '/about',
         },
         {


### PR DESCRIPTION
- on navigation header

closes #781 