### PR TITLE
Move plone/volto docs to respective dirs and add Makefiles for each

### DIFF
--- a/plone-5/Makefile
+++ b/plone-5/Makefile
@@ -1,0 +1,17 @@
+SHELL=bash
+
+.PHONY: all
+all: test build
+
+.PHONY: build
+build:
+	docker build --build-arg POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) --tag plone .
+
+.PHONY: test
+test:
+	./bootstrap.sh
+	./bin/test
+
+.PHONY: debug
+debug: build
+	docker run -p 8080:8080 plone

--- a/plone-5/Makefile
+++ b/plone-5/Makefile
@@ -1,16 +1,11 @@
 SHELL=bash
 
 .PHONY: all
-all: test build
+all: build
 
 .PHONY: build
 build:
 	docker build --build-arg POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) --tag plone .
-
-.PHONY: test
-test:
-	./bootstrap.sh
-	./bin/test
 
 .PHONY: debug
 debug: build

--- a/plone-5/README.md
+++ b/plone-5/README.md
@@ -1,5 +1,9 @@
 # Plone
 
+Before running Plone, you may need to install some [Prerequisites](./plone.md#1-pre-requisites). 
+The following guidance assumes working versions of docker and access to GCP for fetching SQL backups.
+You may also need to run some manual steps to [configure plone](./plone.md#configure-plone) once your containers are running.
+
 Plone requires the following env vars to run and connect to the postgres backend.
 
 | Env var | Description | Deployed Value |

--- a/plone-5/plone.md
+++ b/plone-5/plone.md
@@ -1,7 +1,7 @@
 # Plone Development Environment
 
 Setting up a development environment for Plone can be a bit tricky. Plone currently uses `buildout` to fetch
-dependencies and also to create scripts and configuration files based on those dependencies, and `buildout` support has recently been dropped from IntelliJ/PyCharm.
+dependencies and also to create scripts and configuration files based on those dependencies, but `buildout` support has recently been dropped from IntelliJ/PyCharm.
 
 Since building Plone is already scripted as a Dockerfile and built as a Docker Image, it makes sense to re-use the configuration and scripts to re-create a local environment that can be used in IntelliJ/PyCharm to run and debug our Plone backend.
 
@@ -37,7 +37,7 @@ export CPPFLAGS="-I${ZLIB_BASE}/include"
 ```
 
 ## 2. Bootstrap
-Docker is used to extract a baseline `buildout` config. plone will be run in a Pipenv locally.
+Docker is used to extract a baseline `buildout` config. Plone can be run in a Pipenv locally.
 
 Finally, run `./bootstrap.sh` to create a local, virtualenv (Pipenv) separate environment with all the right dependencies fetched by `buildout` and placed into the `buildout-cache` directory.
 

--- a/volto/Makefile
+++ b/volto/Makefile
@@ -1,0 +1,23 @@
+SHELL=bash
+
+RAZZLE_PATH=http://localhost:8080/climate-change
+
+.PHONY: all
+all: test build
+
+.PHONY: build
+build:
+	yarn build
+
+.PHONY: install
+build:
+	yarn develop && yarn install
+
+.PHONY: test
+test:
+	yarn test
+
+.PHONY: debug
+debug: 
+	yarn run clean
+	RAZZLE_DEV_PROXY_API_PATH=$(RAZZLE_PATH) yarn start:dev

--- a/volto/volto.md
+++ b/volto/volto.md
@@ -54,11 +54,11 @@ This will start containers running plone and volto. Access volto at http://local
 
 The cloned volto dir is bind mounted inside the container. Hot reloading works with this setup.
 
-### <a name='manualsteps'></a> Manual steps
+### Manual steps
 
 You have to start a `plone` instance. See the docs in that directory for the steps on that.
 
-You'll need to have `mrs-developer` installed globally. See the [mrs-developer](#mrsdeveloper) section below.  It's 
+You'll need to have `mrs-developer` installed globally. See the [mrs-developer](#mrs-developer) section below.  It's 
 a tool that clones 3rd party modules from their git repos.
 
 From this `volto` dir,
@@ -151,7 +151,7 @@ If you are switching between git branches, please run following
 
 `yarn run clean`
 
-### <a name='mrsdeveloper'></a> mrs-developer
+### mrs-developer
 
 [mrs-developer](https://github.com/collective/mrs-developer) is a great tool
 for developing multiple packages at the same time.
@@ -159,7 +159,7 @@ for developing multiple packages at the same time.
 mrs-developer should work with this project by running the configured shortcut script:
 
 ```bash
-yarn develop
+yarn global add mrs-developer
 ```
 
 Volto's latest razzle config will pay attention to your jsconfig.json file for any customizations.


### PR DESCRIPTION
I'll rebase this once working-copy is merged.

I've moved the existing plone.md and volto.md files into their correct directories, ahead of potentially separating the repos. 
I've created Makefiles for each plone and volto which should contain at a minimum:
- build: create a production like build or container image
- debug: run the most up to date local code for debugging and working locally
- test: run all unit tests in the application (either volto or plone)

Theoretically, this would mean on top of the `docker compose up` option at a dd-cms root level, the services could be run using `cd plone && make debug` and `cd volto && make debug`. It makes it a bit easier to swap between applications without having to remember language specific details, and will support us building better pipelines in the future.

I would like to improve the volto build command to create the docker image eventually, but for now I'm working with the existing build instructions from the volto.md file