### PR TITLE
Fix cloudbuilds

### DIFF
--- a/deploy/production.yaml
+++ b/deploy/production.yaml
@@ -20,9 +20,9 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/plone:${_IMAGE_TAG}
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/plone:${_IMAGE_TAG}
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/plone:latest
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/plone:latest
       - '--context=dir://plone-5'
       - '--build-arg=POSTGRES_HOST=$_POSTGRES_HOST'
       - '--build-arg=POSTGRES_PASSWORD=$_POSTGRES_PASSWORD'
@@ -34,9 +34,9 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:v1.3.0'
     args:
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/volto:${_IMAGE_TAG}
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/volto:${_IMAGE_TAG}
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/volto:latest
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/volto:latest
       - '--cache=true'
       - '--context=dir://volto'
       - '--build-arg=ADDONS=$_VOLTO_ADDONS'
@@ -54,7 +54,7 @@ steps:
       - deployment/plone
       - '--namespace=cms'
       - >-
-        plone=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/plone:${_IMAGE_TAG}
+        plone=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/plone:${_IMAGE_TAG}
 
   # Update the k8s deployment for volto in the production cluster to use this new image
   # this triggers a green/blue deployment of new image for the running plone pod(s).
@@ -69,7 +69,7 @@ steps:
       - deployment/volto
       - '--namespace=cms'
       - >-
-        volto=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/volto:${_IMAGE_TAG}
+        volto=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/volto:${_IMAGE_TAG}
 
 # Very high timeout (2 hours), but precautionary while we address some build time issues.
 timeout: 7200s

--- a/deploy/sandbox.yaml
+++ b/deploy/sandbox.yaml
@@ -19,7 +19,7 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms-all-branches/plone-$BRANCH_NAME:$SHORT_SHA
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms-all-branches/plone-$BRANCH_NAME:$SHORT_SHA
       - '--cache=true'
       - '--context=dir://plone-5'
       - '--build-arg=POSTGRES_HOST=$_POSTGRES_HOST'
@@ -30,7 +30,7 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:v1.3.0'
     args:
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms-all-branches/volto-$BRANCH_NAME:$SHORT_SHA
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms-all-branches/volto-$BRANCH_NAME:$SHORT_SHA
       - '--cache=true'
       - '--context=dir://volto'
       - '--build-arg=ADDONS=$_VOLTO_ADDONS'
@@ -47,7 +47,7 @@ steps:
       - deployment/plone
       - '--namespace=cms'
       - >-
-        plone=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms-all-branches/plone-$BRANCH_NAME:$SHORT_SHA
+        plone=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms-all-branches/plone-$BRANCH_NAME:$SHORT_SHA
 
   # Update the k8s deployment for volto in the sandbox cluster to use this new image
   # this triggers a green/blue deployment of new image for the running plone pod(s).
@@ -61,7 +61,7 @@ steps:
       - deployment/volto
       - '--namespace=cms'
       - >-
-        volto=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms-all-branches/volto-$BRANCH_NAME:$SHORT_SHA
+        volto=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms-all-branches/volto-$BRANCH_NAME:$SHORT_SHA
 
 # Very high timeout (2 hours), but precautionary while we address some build time issues.
 timeout: 7200s

--- a/deploy/staging.yaml
+++ b/deploy/staging.yaml
@@ -17,9 +17,9 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/plone:staging-$SHORT_SHA
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/plone:staging-$SHORT_SHA
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/plone:staging-latest
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/plone:staging-latest
       - '--cache=true'
       - '--context=dir://plone-5'
       - '--build-arg=POSTGRES_HOST=$_POSTGRES_HOST'
@@ -30,9 +30,9 @@ steps:
   - name: 'gcr.io/kaniko-project/executor:v1.3.0'
     args:
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/volto:staging-$SHORT_SHA
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/volto:staging-$SHORT_SHA
       - >-
-        --destination=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/volto:staging-latest
+        --destination=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/volto:staging-latest
       - '--cache=true'
       - '--context=dir://volto'
       - '--build-arg=ADDONS=$_VOLTO_ADDONS'
@@ -49,7 +49,7 @@ steps:
       - deployment/plone
       - '--namespace=cms'
       - >-
-        plone=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/plone:staging-$SHORT_SHA
+        plone=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/plone:staging-$SHORT_SHA
 
   # Update the k8s deployment for volto in the staging cluster to use this new image
   # this triggers a green/blue deployment of new image for the running plone pod(s).
@@ -63,7 +63,7 @@ steps:
       - deployment/volto
       - '--namespace=cms'
       - >-
-        volto=europe-west2-docker.pkg.dev/optimum-bonbon-257411/dd-cms/volto:staging-$SHORT_SHA
+        volto=europe-west2-docker.pkg.dev/$PROJECT_ID/dd-cms/volto:staging-$SHORT_SHA
 
 # Very high timeout (2 hours), but precautionary while we address some build time issues.
 timeout: 7200s

--- a/plone-5/Dockerfile
+++ b/plone-5/Dockerfile
@@ -6,8 +6,9 @@ ARG POSTGRES_USER=plone
 ARG POSTGRES_HOST=172.17.0.1
 # don't default this, in case of mix ups with builds
 ARG POSTGRES_PASSWORD
-# location of the zope config, shouldn't change but lets not repeat ourselves
+# location of the zope config and temp config, shouldn't change but lets not repeat ourselves
 ARG ZOPE_CONF_LOCATION=/plone/instance/parts/instance/etc/zope.conf
+ARG ZOPE_TEMP_CONFIG=/plone/instance/parts/instance/etc/zope-temporary.conf
 
 # Check for mandatory build argument POSTGRES_PASSWORD
 RUN \
@@ -27,10 +28,10 @@ COPY build-and-start.sh /usr/local/bin/build-and-start
 COPY ./zope.conf $ZOPE_CONF_LOCATION
 
 # Horrid sed hack to inject build args into zope.conf as plone doesn't
-# sem to evalute new/unexpected environment variables at run time
+# seem to evalute new/unexpected environment variables at run time.
 RUN sed -i "s/POSTGRES_DB/$POSTGRES_DB/g" $ZOPE_CONF_LOCATION
 RUN sed -i "s/POSTGRES_USER/$POSTGRES_USER/g" $ZOPE_CONF_LOCATION
 RUN sed -i "s/POSTGRES_HOST/$POSTGRES_HOST/g" $ZOPE_CONF_LOCATION
-RUN sed -i "s/POSTGRES_PASSWORD/$POSTGRES_PASSWORD/g" $ZOPE_CONF_LOCATION
+RUN sed -i "s/POSTGRES_PASSWORD/"$POSTGRES_PASSWORD"/g" $ZOPE_CONF_LOCATION
 
 CMD gosu plone bin/instance console

--- a/plone-5/Dockerfile
+++ b/plone-5/Dockerfile
@@ -6,9 +6,8 @@ ARG POSTGRES_USER=plone
 ARG POSTGRES_HOST=172.17.0.1
 # don't default this, in case of mix ups with builds
 ARG POSTGRES_PASSWORD
-# location of the zope config and temp config, shouldn't change but lets not repeat ourselves
+# location of the zope config, shouldn't change but lets not repeat ourselves
 ARG ZOPE_CONF_LOCATION=/plone/instance/parts/instance/etc/zope.conf
-ARG ZOPE_TEMP_CONFIG=/plone/instance/parts/instance/etc/zope-temporary.conf
 
 # Check for mandatory build argument POSTGRES_PASSWORD
 RUN \
@@ -29,9 +28,9 @@ COPY ./zope.conf $ZOPE_CONF_LOCATION
 
 # Horrid sed hack to inject build args into zope.conf as plone doesn't
 # seem to evalute new/unexpected environment variables at run time.
-RUN sed -i "s/POSTGRES_DB/$POSTGRES_DB/g" $ZOPE_CONF_LOCATION
-RUN sed -i "s/POSTGRES_USER/$POSTGRES_USER/g" $ZOPE_CONF_LOCATION
-RUN sed -i "s/POSTGRES_HOST/$POSTGRES_HOST/g" $ZOPE_CONF_LOCATION
+RUN sed -i "s/POSTGRES_DB/"$POSTGRES_DB"/g" $ZOPE_CONF_LOCATION
+RUN sed -i "s/POSTGRES_USER/"$POSTGRES_USER"/g" $ZOPE_CONF_LOCATION
+RUN sed -i "s/POSTGRES_HOST/"$POSTGRES_HOST"/g" $ZOPE_CONF_LOCATION
 RUN sed -i "s/POSTGRES_PASSWORD/"$POSTGRES_PASSWORD"/g" $ZOPE_CONF_LOCATION
 
 CMD gosu plone bin/instance console

--- a/plone-5/zope.conf
+++ b/plone-5/zope.conf
@@ -20,7 +20,7 @@ cache-size 30000
 <relstorage>
     blob-dir /data/blob-cache
     <postgresql>
-    dsn dbname='POSTGRES_DB' user='POSTGRES_USER' host=POSTGRES_HOST port=5432 password='POSTGRES_PASSWORD'
+    dsn dbname='POSTGRES_DB' user='POSTGRES_USER' host='POSTGRES_HOST' port=5432 password='POSTGRES_PASSWORD'
     </postgresql>
 </relstorage>
 mount-point /

--- a/plone-5/zope.conf
+++ b/plone-5/zope.conf
@@ -20,7 +20,7 @@ cache-size 30000
 <relstorage>
     blob-dir /data/blob-cache
     <postgresql>
-    dsn dbname='POSTGRES_DB' user='POSTGRES_USER' host='POSTGRES_HOST' port=5432 password='POSTGRES_PASSWORD'
+    dsn dbname='POSTGRES_DB' user='POSTGRES_USER' host=POSTGRES_HOST port=5432 password='POSTGRES_PASSWORD'
     </postgresql>
 </relstorage>
 mount-point /


### PR DESCRIPTION
two things:

### Sed

Sed uses regex patterns and our randomly generated database passwords are allowed to use special characters - this means we're currently inserting string that sometimes have (inadvertent) syntactic meaning, this was leading to some unexpected behaviours.

example:

```
sed -i "s/POSTGRES_PASSWORD/$POSTGRES_PASSWORD/g"
```

where `$POSTGRES_PASSWORD` is `1234&1234` would result in an injected password of `1234POSTGRES_PASSWORD1234` as `&` indicates "insert initial string".

Enclosing the value to be inserted (`$POSTGRES_PASSWORD` ) in quotes (as below) makes it a literal replacement.

```
sed -i "s/POSTGRES_PASSWORD/"$POSTGRES_PASSWORD"/g"
```

It shouldn't matter for the others but have included quotes for them as well as future proofing.


### $PROJECT_ID

GCP has an automatically created GCP cloud build variable of `$PROJECT_ID` . Have switched to using this in the build definitions as it makes them slightly more portable to other GCP projects.


### How to review

Sanity check please. Already tested and working in sandbox.