### PR TITLE
issue-752/Dashboard tiles horizontal bar visualisation - rounding error

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/Bar/Bar.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/TileVis/Bar/Bar.jsx
@@ -18,6 +18,7 @@ const Bar = ({ data, height }) => {
       />
     );
   });
+
   return (
     <Fragment>
       <div className="cc-bar-container" data-testid="bar">
@@ -28,8 +29,8 @@ const Bar = ({ data, height }) => {
       <ValuesBlock
         xStart={data[0].category}
         xEnd={data[1].category}
-        yStart={`${Math.floor(data[0].value)}%`}
-        yEnd={`${Math.floor(data[1].value)}%`}
+        yStart={`${Math.round(data[0].value)}%`}
+        yEnd={`${Math.round(data[1].value)}%`}
         xColor={data[0].color}
         yColor={data[0].color}
         isABar={true}


### PR DESCRIPTION
This ticket solves an issue with the value on the dashboard tile always being rounded down.

Previous -  14 and 84
![image](https://user-images.githubusercontent.com/110108574/218981635-0ee09457-aa39-4afd-a5de-dab6c515cc03.png)

Updated - 15 and 84
![image](https://user-images.githubusercontent.com/110108574/218981811-2a301258-6bd0-46f1-a5ca-ba84abab5270.png)

I think there's some issues still to be answered around design of handling edge cases.
If there are two .5 which way do we want to round them? or do we want to show the decimal place in this case?
There is also the possibility of giving the user the ability to set the decimal place in the side panel, but that might fall under a separate ticket.
There's also the question of the two values on the mitigation tile not equating to 100, the values before rounding are 14.64 and 84.11. 