### PR TITLE
Issuee 827/stop contact form view being accessible

### DIFF
--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/config/NonContentRoutes.jsx
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/config/NonContentRoutes.jsx
@@ -21,7 +21,6 @@ export const nonContentRoutes = [
   '/change-password',
   /\/controlpanel\/.*$/,
   '/controlpanel',
-  '/contact-form',
   '/personal-information',
   '/personal-preferences',
   '/register',

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/config/NonContentRoutes.jsx
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/config/NonContentRoutes.jsx
@@ -1,0 +1,33 @@
+import config from '@plone/volto/registry';
+
+// Non Content Routes/Views
+// You can include either RegEx or a string representing the ending of the
+// nonContentRoute eg. '/add' will match '/foo/bar/add'
+export const nonContentRoutes = [
+  /\?.*$/,
+  /\/add$/,
+  '/contents',
+  '/delete',
+  '/diff',
+  /\/edit$/,
+  '/history',
+  '/layout',
+  '/login',
+  '/logout',
+  '/sitemap',
+  '/register',
+  '/sharing',
+  '/search',
+  '/change-password',
+  /\/controlpanel\/.*$/,
+  '/controlpanel',
+  '/contact-form',
+  '/personal-information',
+  '/personal-preferences',
+  '/register',
+  /\/password-reset\/.*$/,
+  '/password-reset',
+  '/create-translation',
+  '/manage-translations',
+  ...(config.settings?.externalRoutes?.map((route) => route.match.path) || []),
+];

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/routes.js
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/routes.js
@@ -6,7 +6,6 @@ import {
   Add,
   AddonsControlpanel,
   ChangePassword,
-  ContactForm,
   Contents,
   ContentType,
   ContentTypeLayout,
@@ -57,10 +56,6 @@ export const multilingualRoutes = [
     component: Search,
   },
   {
-    path: `/(${config.settings?.supportedLanguages.join('|')})/contact-form`,
-    component: ContactForm,
-  },
-  {
     path: `/(${config.settings?.supportedLanguages.join('|')})/change-password`,
     component: ChangePassword,
   },
@@ -103,10 +98,6 @@ export const defaultRoutes = [
   {
     path: '/search',
     component: Search,
-  },
-  {
-    path: '/contact-form',
-    component: ContactForm,
   },
   {
     path: '/controlpanel',

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/routes.js
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/routes.js
@@ -1,0 +1,267 @@
+/**
+ * Routes.
+ * @module routes
+ */
+import {
+  Add,
+  AddonsControlpanel,
+  ChangePassword,
+  ContactForm,
+  Contents,
+  ContentType,
+  ContentTypeLayout,
+  ContentTypeSchema,
+  ContentTypes,
+  Controlpanel,
+  Controlpanels,
+  CreateTranslation,
+  DatabaseInformation,
+  Delete,
+  Diff,
+  Edit,
+  History,
+  Login,
+  Logout,
+  ManageTranslations,
+  ModerateComments,
+  NotFound,
+  PasswordReset,
+  Register,
+  RequestPasswordReset,
+  Search,
+  Sharing,
+  Sitemap,
+  UsersControlpanel,
+  GroupsControlpanel,
+} from '@plone/volto/components';
+
+// Deliberatelly use of absolute path of these components, since we do not want them
+// in the components/index.js file.
+import App from '@plone/volto/components/theme/App/App';
+import View from '@plone/volto/components/theme/View/View';
+
+import config from '@plone/volto/registry';
+
+/**
+ * Default routes array.
+ * @array
+ * @returns {array} Routes.
+ */
+export const multilingualRoutes = [
+  {
+    path: `/(${config.settings?.supportedLanguages.join('|')})/sitemap`,
+    component: Sitemap,
+  },
+  {
+    path: `/(${config.settings?.supportedLanguages.join('|')})/search`,
+    component: Search,
+  },
+  {
+    path: `/(${config.settings?.supportedLanguages.join('|')})/contact-form`,
+    component: ContactForm,
+  },
+  {
+    path: `/(${config.settings?.supportedLanguages.join('|')})/change-password`,
+    component: ChangePassword,
+  },
+  {
+    path: `/(${config.settings?.supportedLanguages.join('|')})/register`,
+    component: Register,
+  },
+  {
+    path: `/(${config.settings?.supportedLanguages.join('|')})/password-reset`,
+    component: RequestPasswordReset,
+    exact: true,
+  },
+  {
+    path: `/(${config.settings?.supportedLanguages.join(
+      '|',
+    )})/password-reset/:token`,
+    component: PasswordReset,
+    exact: true,
+  },
+];
+
+export const defaultRoutes = [
+  {
+    path: '/',
+    component: View,
+    exact: true,
+  },
+  {
+    path: '/login',
+    component: Login,
+  },
+  {
+    path: '/logout',
+    component: Logout,
+  },
+  {
+    path: '/sitemap',
+    component: Sitemap,
+  },
+  {
+    path: '/search',
+    component: Search,
+  },
+  {
+    path: '/contact-form',
+    component: ContactForm,
+  },
+  {
+    path: '/controlpanel',
+    exact: true,
+    component: Controlpanels,
+  },
+  {
+    path: '/controlpanel/dexterity-types/:id/layout',
+    component: ContentTypeLayout,
+  },
+  {
+    path: '/controlpanel/dexterity-types/:id/schema',
+    component: ContentTypeSchema,
+  },
+  {
+    path: '/controlpanel/dexterity-types/:id',
+    component: ContentType,
+  },
+  {
+    path: '/controlpanel/dexterity-types',
+    component: ContentTypes,
+  },
+  {
+    path: '/controlpanel/addons',
+    component: AddonsControlpanel,
+  },
+  {
+    path: '/controlpanel/database',
+    component: DatabaseInformation,
+  },
+  {
+    path: '/controlpanel/moderate-comments',
+    component: ModerateComments,
+  },
+  {
+    path: '/controlpanel/users',
+    component: UsersControlpanel,
+  },
+  {
+    path: '/controlpanel/groups',
+    component: GroupsControlpanel,
+  },
+  {
+    path: '/controlpanel/:id',
+    component: Controlpanel,
+  },
+  {
+    path: '/change-password',
+    component: ChangePassword,
+  },
+  {
+    path: '/add',
+    component: Add,
+  },
+  {
+    path: '/edit',
+    component: Edit,
+  },
+  {
+    path: '/contents',
+    component: Contents,
+  },
+  {
+    path: '/sharing',
+    component: Sharing,
+  },
+  {
+    path: '/**/add',
+    component: Add,
+  },
+  {
+    path: '/**/create-translation',
+    component: CreateTranslation,
+  },
+  {
+    path: '/**/contents',
+    component: Contents,
+  },
+  {
+    path: '/**/sharing',
+    component: Sharing,
+  },
+  {
+    path: '/**/delete',
+    component: Delete,
+  },
+  {
+    path: '/**/diff',
+    component: Diff,
+  },
+  {
+    path: '/**/edit',
+    component: Edit,
+  },
+  {
+    path: '/**/history',
+    component: History,
+  },
+  {
+    path: '/**/sharing',
+    component: Sharing,
+  },
+  {
+    path: '/**/manage-translations',
+    component: ManageTranslations,
+  },
+  {
+    path: '/**/login',
+    component: Login,
+  },
+  {
+    path: '/register',
+    component: Register,
+  },
+  {
+    path: '/password-reset',
+    component: RequestPasswordReset,
+    exact: true,
+  },
+  {
+    path: '/password-reset/:token',
+    component: PasswordReset,
+    exact: true,
+  },
+  {
+    path: '/**',
+    component: View,
+  },
+  {
+    path: '*',
+    component: NotFound,
+  },
+];
+
+/**
+ * Routes array.
+ * @array
+ * @returns {array} Routes.
+ */
+const routes = [
+  {
+    path: '/',
+    component: App,
+    routes: [
+      // redirect to external links if path is in blacklist
+      ...(config.settings?.externalRoutes || []).map((route) => ({
+        ...route.match,
+        component: NotFound,
+      })),
+      // addon routes have a higher priority then default routes
+      ...(config.addonRoutes || []),
+      ...((config.settings?.isMultilingual && multilingualRoutes) || []),
+      ...defaultRoutes,
+    ],
+  },
+];
+
+export default routes;


### PR DESCRIPTION
Add '/contact-form' to the end of the url and it will now lead to 404 page.

Here are the other urls in use.
![image](https://user-images.githubusercontent.com/110108574/220145069-63ce6a5a-4452-46f4-ac10-53d7461802d1.png)

closes #827 