### PR TITLE
Update makefiles to include test targets

### DIFF
--- a/plone-5/Makefile
+++ b/plone-5/Makefile
@@ -7,6 +7,11 @@ all: build
 build:
 	docker build --build-arg POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) --tag plone .
 
+.PHONY: test
+test:
+	./bootstrap.sh develop.cfg
+	sudo ./instance/bin/test
+
 .PHONY: debug
 debug: build
 	docker run -p 8080:8080 plone

--- a/plone-5/bootstrap.sh
+++ b/plone-5/bootstrap.sh
@@ -18,7 +18,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   # and it doesn't find it without these env vars...
   ZLIB_BASE=$(brew --prefix zlib)
   export LDFLAGS="-L${ZLIB_BASE}/lib"
-  export CPPFLAGS="-I${ZLIB_BASE}/include"
+  export CPPFLAGS="-I${ZLIB_BASE}/include -Wno-error=implicit-function-declaration"
 else
     sed -i 's|var-dir=/data|var-dir=data|;/RelStorage\|psycopg2\|mysqlclient\|cx-Oracle\|ldap/d' instance/buildout.cfg
 fi
@@ -35,7 +35,12 @@ export $(docker inspect --format='{{join .Config.Env " "}}' plone:${PLONE_VERSIO
 # restore my path variable
 export PATH=$mypath
 
-pipenv install requests pip==$PIP setuptools==$SETUPTOOLS zc.buildout==$ZC_BUILDOUT wheel==$WHEEL
+sudo pipenv install requests pip==$PIP setuptools==$SETUPTOOLS zc.buildout==$ZC_BUILDOUT wheel==$WHEEL
 cd instance
-pipenv run buildout -c custom.cfg
+
+if [[ -z "$1" ]]; then
+  sudo pipenv run buildout -c custom.cfg
+else
+  sudo pipenv run buildout -c $1
+fi
 cd ..

--- a/plone-5/plone.md
+++ b/plone-5/plone.md
@@ -33,13 +33,15 @@ brew install pipenv zlib libjpeg
 # zlib
 ZLIB_BASE=$(brew --prefix zlib)
 export LDFLAGS="-L${ZLIB_BASE}/lib"
-export CPPFLAGS="-I${ZLIB_BASE}/include"
+export CPPFLAGS="-I${ZLIB_BASE}/include -Wno-error=implicit-function-declaration"
 ```
 
 ## 2. Bootstrap
 Docker is used to extract a baseline `buildout` config. Plone can be run in a Pipenv locally.
 
 Finally, run `./bootstrap.sh` to create a local, virtualenv (Pipenv) separate environment with all the right dependencies fetched by `buildout` and placed into the `buildout-cache` directory.
+
+Optionally, running `./bootstrap.sh <filename>` with the name of another .cfg file will force the buildout stage to use that configuration. It uses `custom.cfg` by default, but `./bootstrap.sh develop.cfg` may be necessary to generate test scripts.
 
 ## 3. Launch
 

--- a/volto/Makefile
+++ b/volto/Makefile
@@ -15,7 +15,7 @@ build:
 
 .PHONY: test
 test:
-	yarn test
+	yarn test --watchAll=false
 
 .PHONY: debug
 debug: 


### PR DESCRIPTION
- Add test target for Volto, ensuring the interactive prompt is disabled
- Add test target for Plone, ensuring the preceding buildout steps work:
  - `sudo`s added to pipenv commands
  - `noerror` flag added to CPPflags
 - Extend bootstrap.sh to accept arguments declaring which buildout .cfg file to use and update documentation

NB: the tests don't all pass, but at least they are runnable and output their results which is the scope of this makefile