### PR TITLE
Fixed bug with uninitialised phaseData

### DIFF
--- a/volto/src/addons/volto-climatechange-elements/src/components/CcPhaseBannerWrapper/CcPhaseBannerWrapper.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/components/CcPhaseBannerWrapper/CcPhaseBannerWrapper.jsx
@@ -23,12 +23,14 @@ export const CcPhaseBannerWrapper = ({ className }) => {
 
   useEffect(() => {
     var obj = phaseData;
-    setPhaseBannerStage(obj.bannerStage);
-    setPhaseBannerDisplay(obj.bannerDisplay);
-    if (obj.bannerLinkType == 'mailto') {
-      setPhaseBannerLink('mailto:' + obj.bannerLink);
-    } else {
-      setPhaseBannerLink(obj.bannerLink);
+    if (obj){
+      setPhaseBannerStage(obj.bannerStage);
+      setPhaseBannerDisplay(obj.bannerDisplay);
+      if (obj.bannerLinkType == 'mailto') {
+        setPhaseBannerLink('mailto:' + obj.bannerLink);
+      } else {
+        setPhaseBannerLink(obj.bannerLink);
+      }
     }
   }, [phaseData]);
 


### PR DESCRIPTION
This initially gets set to null on page load but is called again once the right data has been acquired.

Causing the following errors:

![image](https://user-images.githubusercontent.com/73846016/221626119-e3854c03-fabc-4531-a72a-ac1c93a245b7.png)

```
Unhandled Rejection (TypeError): obj is null
./src/addons/volto-climatechange-elements/src/components/CcPhaseBannerWrapper/CcPhaseBannerWrapper.jsx/</CcPhaseBannerWrapper/<
src/addons/volto-climatechange-elements/src/components/CcPhaseBannerWrapper/CcPhaseBannerWrapper.jsx:27

  24 | useEffect(() => {
  25 |   var obj = phaseData;
  26 |   // if (obj){
> 27 |     setPhaseBannerStage(obj.bannerStage);
     | ^  28 |     setPhaseBannerDisplay(obj.bannerDisplay);
  29 |     if (obj.bannerLinkType == 'mailto') {
  30 |       setPhaseBannerLink('mailto:' + obj.bannerLink);
```

Which caused that component to fail and cascaded to the following error: 

![image](https://user-images.githubusercontent.com/73846016/221626043-3ce459d7-aee8-4882-acba-d706cdf4db53.png)

```
Unhandled Rejection (TypeError): this.$module is null
SuperNavigationMegaMenu
src/addons/volto-climatechange-elements/src/components/CcSuperNavigationHeader/layout-super-navigation-header.js:108

  105 | 
  106 | function SuperNavigationMegaMenu ($module) {
  107 |   this.$module = $module
> 108 |   this.$navigationToggle = this.$module.querySelector('#super-navigation-menu-toggle')
      | ^  109 |   this.$navigationMenu = this.$module.querySelector('#super-navigation-menu')
  110 |   this.$searchToggle = this.$module.querySelector('#super-search-menu-toggle')
  111 |   this.$searchMenu = this.$module.querySelector('#super-search-menu')
```
