### PR TITLE
change chart_builder tag to v1.1.1

### DIFF
--- a/volto/mrs.developer.json
+++ b/volto/mrs.developer.json
@@ -7,6 +7,6 @@
   },
   "chart-builder": {
     "url": "https://github.com/GSS-Cogs/chart-builder/",
-    "tag": "v1.1.0"
+    "tag": "v1.1.1"
   }
 }


### PR DESCRIPTION
This fixed an issue with maps not loading.
/dashboards/adaptation has one to checkout.