### PR TITLE
rename 'class' to 'className'

### DIFF
--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/NotFound/NotFound.jsx
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/NotFound/NotFound.jsx
@@ -15,28 +15,28 @@ import { withServerErrorCode } from '@plone/volto/helpers/Utils/Utils';
  * @returns {string} Markup of the not found page.
  */
 const NotFound = () => (
-  <div class="app-width-container">
+  <div className="app-width-container">
     <main
-      class="govuk-main-wrapper govuk-main-wrapper--l"
+      className="govuk-main-wrapper govuk-main-wrapper--l"
       id="main-content"
       role="main"
     >
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <h1 className="govuk-heading-xl govuk-!-margin-bottom-9">
             Page not found
           </h1>
-          <p class="govuk-body">
+          <p className="govuk-body">
             If you typed the web address, check it is correct.
           </p>
-          <p class="govuk-body">
+          <p className="govuk-body">
             You can{' '}
-            <a href="/" class="govuk-link">
+            <a href="/" className="govuk-link">
               browse from the homepage
             </a>{' '}
             or use the search box above to find the information you need.
           </p>
-          <p class="govuk-body">Status code: 404</p>
+          <p className="govuk-body">Status code: 404</p>
         </div>
       </div>
     </main>

--- a/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/NotFound/__snapshots__/NotFound.test.jsx.snap
+++ b/volto/src/addons/volto-govuk-theme/src/customizations/volto/components/theme/NotFound/__snapshots__/NotFound.test.jsx.snap
@@ -2,36 +2,36 @@
 
 exports[`NotFound renders a not found component 1`] = `
 <div
-  class="app-width-container"
+  className="app-width-container"
 >
   <main
-    class="govuk-main-wrapper govuk-main-wrapper--l"
+    className="govuk-main-wrapper govuk-main-wrapper--l"
     id="main-content"
     role="main"
   >
     <div
-      class="govuk-grid-row"
+      className="govuk-grid-row"
     >
       <div
-        class="govuk-grid-column-two-thirds"
+        className="govuk-grid-column-two-thirds"
       >
         <h1
-          class="govuk-heading-xl govuk-!-margin-bottom-9"
+          className="govuk-heading-xl govuk-!-margin-bottom-9"
         >
           Page not found
         </h1>
         <p
-          class="govuk-body"
+          className="govuk-body"
         >
           If you typed the web address, check it is correct.
         </p>
         <p
-          class="govuk-body"
+          className="govuk-body"
         >
           You can
            
           <a
-            class="govuk-link"
+            className="govuk-link"
             href="/"
           >
             browse from the homepage
@@ -40,7 +40,7 @@ exports[`NotFound renders a not found component 1`] = `
           or use the search box above to find the information you need.
         </p>
         <p
-          class="govuk-body"
+          className="govuk-body"
         >
           Status code: 404
         </p>


### PR DESCRIPTION
This fixes a warning that kept popping up on the NotFound view.
Just renaming 'class' to 'className'

`Warning: Invalid DOM property class`