### PR TITLE
change regex to remove lookbehind

### DIFF
--- a/volto/src/helpers/index.js
+++ b/volto/src/helpers/index.js
@@ -18,9 +18,9 @@ const replaceUrl = (originalPath, parentPath) => {
   if (!originalPath) {
     return originalPath;
   }
-  const dashboard_name = parentPath.match(/(?<=\/dashboards\/).*./);
+  const dashboard_name = parentPath.match(/(?:\/dashboards\/).*./);
   const possible_url = originalPath.replace(
-    /(?<=\/dashboards\/).+?(?=\/)/,
+    /(?:\/dashboards\/).+?(?=\/)/,
     dashboard_name,
   );
   return possible_url;


### PR DESCRIPTION
This ticket was to address an issue with parts of the site not loading when using Safari.

The issue was with regex and that Safari does not support the[lookbehind](https://caniuse.com/js-regexp-lookbehind) function that was used within, so non-capturing group is used.
This is the '?<=\' part, and has been updated too '?:\', which does the same job and is supported by Safari.