### PR TITLE
change chart builder tag to v1.2.1

### DIFF
--- a/volto/mrs.developer.json
+++ b/volto/mrs.developer.json
@@ -7,6 +7,6 @@
   },
   "chart-builder": {
     "url": "https://github.com/GSS-Cogs/chart-builder/",
-    "tag": "v1.1.1"
+    "tag": "v1.2.1"
   }
 }


### PR DESCRIPTION
change chart builder tag. v1.2.1 is used because of a bug fix and latest release.