### PR TITLE
Issue 755/make the endpoint for site wide properties public

### DIFF
--- a/plone-5/instance/src/ukstats.ccv2.content_types/src/ukstats/ccv2/content_types/api/configure.zcml
+++ b/plone-5/instance/src/ukstats.ccv2.content_types/src/ukstats/ccv2/content_types/api/configure.zcml
@@ -1,0 +1,22 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="ukstats.ccv2.content_types">
+
+    <plone:service
+    method="GET"
+    for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+    factory=".controlpanel.PhaseBanner"
+    name="@cmsconf-phase_banner"
+    permission="zope2.View"
+    />
+
+    <plone:service
+    method="GET"
+    for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+    factory=".controlpanel.SiteTitle"
+    name="@cmsconf-site_title"
+    permission="zope2.View"
+    />
+</configure>

--- a/plone-5/instance/src/ukstats.ccv2.content_types/src/ukstats/ccv2/content_types/api/controlpanel.py
+++ b/plone-5/instance/src/ukstats.ccv2.content_types/src/ukstats/ccv2/content_types/api/controlpanel.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from plone import api
+from plone.restapi.services import Service
+
+reg_base = 'cmsconf'
+
+
+class SiteTitle(Service):
+    def reply(self):
+        registry_record_value = api.portal.get_registry_record(reg_base + '.site_title')
+        return registry_record_value
+
+
+class PhaseBanner(Service):
+    def reply(self):
+        phasebanner_state = api.portal.get_registry_record(
+            reg_base + '.phasebanner_state')
+        feedback_email = api.portal.get_registry_record(reg_base + '.feedback_email')
+        return {'bannerDisplay': phasebanner_state, 'bannerLink': feedback_email}

--- a/plone-5/instance/src/ukstats.ccv2.content_types/src/ukstats/ccv2/content_types/configure.zcml
+++ b/plone-5/instance/src/ukstats.ccv2.content_types/src/ukstats/ccv2/content_types/configure.zcml
@@ -14,7 +14,7 @@
   <!--<includeDependencies package="." />-->
 
   <include package=".browser" />
-
+  <include package=".api" />
   <include file="permissions.zcml" />
 
   <genericsetup:registerProfile

--- a/volto/src/addons/volto-climatechange-elements/src/actions/index.js
+++ b/volto/src/addons/volto-climatechange-elements/src/actions/index.js
@@ -73,7 +73,7 @@ export function getSiteTitle() {
     type: GET_SITE_TITLE,
     request: {
       op: 'get',
-      path: '@controlpanels/cmsconf-controlpanel',
+      path: '@cmsconf-site_title',
       headers: {},
     },
     url: '',

--- a/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/volto/src/addons/volto-climatechange-elements/src/customizations/volto/components/theme/Header/Header.jsx
@@ -57,7 +57,7 @@ const Header = (props) => {
     (state) => state.reduxAsyncConnect.navigation?.items ?? [],
   );
   const siteTitle = useSelector(
-    (state) => state.rawSiteTitle?.siteTitle?.data?.data?.site_title ?? '',
+    (state) => state.rawSiteTitle?.siteTitle?.data ?? '',
   );
 
   const menu_contents = [];


### PR DESCRIPTION
With this ticket I've made use of a custom Plone restapi which sets up an endpoint used within a redux action.
With this only the site title and phase banner settings are available, with only site title being fully implemented on the frontend at the moment. Implementing the phase banner settings would overwrite the current ones that are set on the landing page, requiring all sites to go in and update them in site setup. Might need a talk as when best to do this.
I've left out the Google and Hotjar ids as I'm not sure we would wan these to be public or not?

**To test**

- Run a local instance the cms
- login
- Goto site setup, bottom left
- Goto cms settings under 'add-on configuration'
- add a site title and hit save, top left
- refresh the page to confirm its in place at the top
- logout
- go to any page and title should be there still
or you can goto `http://localhost:3000/++api++/@cmsconf-site_title`

If cms settings isn't available:
- goto site setup
- then add-ons
- uninstall 'UKSTATS.CCV2.CONTENT_TYPES'
- reinstall 'UKSTATS.CCV2.CONTENT_TYPES'
cms settings should now appear
