### PR TITLE
issue-478/Remove-DISCODATA-connector

### DIFF
--- a/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
+++ b/volto/src/addons/volto-chart-builder/src/components/ChartBuilderEdit.jsx
@@ -50,7 +50,6 @@ const Edit = (props) => {
                     pattern_options: {
                       selectableTypes: [
                         'File',
-                        'discodataconnector',
                         'sparql_dataconnector',
                         'csv_type',
                       ],
@@ -77,11 +76,7 @@ const Edit = (props) => {
                 error={geoJsonError}
                 widgetOptions={{
                   pattern_options: {
-                    selectableTypes: [
-                      'discodataconnector',
-                      'csv_type',
-                      'sparql_dataconnector',
-                    ],
+                    selectableTypes: ['csv_type', 'sparql_dataconnector'],
                   },
                 }}
                 value={data.geojson_path || []}

--- a/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/schema.js
+++ b/volto/src/addons/volto-climatechange-elements/src/components/DashboardTile/schema.js
@@ -4,96 +4,99 @@ export const VIS_SPARK_LINE = 'spark_line';
 export const VIS_BAR = 'bar';
 
 export const DashboardTileSchema = ({ intl }) => ({
-    title: 'Dashboard Tile',
+  title: 'Dashboard Tile',
 
-    fieldsets: [
-        {
-            id: 'default',
-            title: intl.formatMessage(messages.defaultFieldset),
-            fields: ['topic', 'title'],
-        },
-        {
-            id: 'data',
-            title: intl.formatMessage(messages.dataFieldset),
-            fields: ['vis_type', 'data_source'],
-        },
-        {
-            id: 'footer',
-            title: intl.formatMessage(messages.footerLinkFieldset),
-            fields: ['href', 'linkTitle'],
-        },
-    ],
-
-    properties: {
-        topic: {
-            type: 'string',
-            title: intl.formatMessage(messages.topic),
-        },
-        title: {
-            type: 'string',
-            title: intl.formatMessage(messages.title),
-        },
-        vis_type: {
-            title: intl.formatMessage(messages.vis_type),
-            choices: [[VIS_SPARK_LINE, 'Spark Line'], [VIS_BAR, 'Bar']],
-        },
-        data_source: {
-            widget: 'object_browser',
-            title: intl.formatMessage(messages.data_source),
-            widgetOptions: {
-                pattern_options: {
-                    selectableTypes: ['discodataconnector', 'sparql_dataconnector', 'csv_type'],
-                }
-            },
-        },
-        href: {
-            type: 'string',
-            title: intl.formatMessage(messages.href),
-        },
-        linkTitle: {
-            type: 'string',
-            title: intl.formatMessage(messages.linkTitle),
-        },
+  fieldsets: [
+    {
+      id: 'default',
+      title: intl.formatMessage(messages.defaultFieldset),
+      fields: ['topic', 'title'],
     },
+    {
+      id: 'data',
+      title: intl.formatMessage(messages.dataFieldset),
+      fields: ['vis_type', 'data_source'],
+    },
+    {
+      id: 'footer',
+      title: intl.formatMessage(messages.footerLinkFieldset),
+      fields: ['href', 'linkTitle'],
+    },
+  ],
 
-    required: ['topic', 'title'],
+  properties: {
+    topic: {
+      type: 'string',
+      title: intl.formatMessage(messages.topic),
+    },
+    title: {
+      type: 'string',
+      title: intl.formatMessage(messages.title),
+    },
+    vis_type: {
+      title: intl.formatMessage(messages.vis_type),
+      choices: [
+        [VIS_SPARK_LINE, 'Spark Line'],
+        [VIS_BAR, 'Bar'],
+      ],
+    },
+    data_source: {
+      widget: 'object_browser',
+      title: intl.formatMessage(messages.data_source),
+      widgetOptions: {
+        pattern_options: {
+          selectableTypes: ['sparql_dataconnector', 'csv_type'],
+        },
+      },
+    },
+    href: {
+      type: 'string',
+      title: intl.formatMessage(messages.href),
+    },
+    linkTitle: {
+      type: 'string',
+      title: intl.formatMessage(messages.linkTitle),
+    },
+  },
+
+  required: ['topic', 'title'],
 });
 
 const messages = defineMessages({
-    defaultFieldset: {
-        id: 'Default',
-        defaultMessage: 'Default',
-    },
-    footerLinkFieldset: {
-        id: 'footerLinkFieldset',
-        defaultMessage: 'Footer Link',
-    },
-    dataFieldset: {
-        id: 'dataFieldset',
-        defaultMessage: 'Data',
-    },
-    topic: {
-        id: 'Topic',
-        defaultMessage: 'Topic',
-    },
-    title: {
-        id: 'Title',
-        defaultMessage: 'Title',
-    },
-    href: {
-        id: 'HREF',
-        defaultMessage: 'Link Address',
-    },
-    linkTitle: {
-        id: 'linkTitle',
-        defaultMessage: 'Link Title',
-    },
-    data_source: {
-        id: 'data',
-        defaultMessage: 'Data'
-    },
-    vis_type: {
-        id: 'vis_type',
-        defaultMessage: 'Visualisation Type',
-    },
+  defaultFieldset: {
+    id: 'Default',
+    defaultMessage: 'Default',
+  },
+  footerLinkFieldset: {
+    id: 'footerLinkFieldset',
+    defaultMessage: 'Footer Link',
+  },
+  dataFieldset: {
+    id: 'dataFieldset',
+    defaultMessage: 'Data',
+  },
+  topic: {
+    id: 'Topic',
+    defaultMessage: 'Topic',
+  },
+  title: {
+    id: 'Title',
+    defaultMessage: 'Title',
+  },
+  href: {
+    id: 'HREF',
+    defaultMessage: 'Link Address',
+  },
+  linkTitle: {
+    id: 'linkTitle',
+    defaultMessage: 'Link Title',
+  },
+  data_source: {
+    id: 'data',
+    defaultMessage: 'Data',
+  },
+  vis_type: {
+    id: 'vis_type',
+    defaultMessage: 'Visualisation Type',
+  },
 });


### PR DESCRIPTION
This ticket removes the `discodata_connector` from being a selectable type in dashboard tiles and chart builder edit.