### PR TITLE
Customized the Exception Logging(SPARQL Data Connector)

### DIFF
--- a/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
+++ b/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
@@ -24,10 +24,12 @@ class SPARQLDataProviderForConnectors(object):
     def __init__(self, context, request):
         self.context = context
         self.request = request
+        
 
     @timing
     def _get_data(self):
         endpoint_url = self.context.endpoint_url
+        title = self.context.title
         query = self.context.sparql_query
 
         sparql = SPARQLWrapper(endpoint_url)
@@ -36,8 +38,8 @@ class SPARQLDataProviderForConnectors(object):
 
         try:
             results = sparql.query().convert()
-        except Exception as e:
-            logger.exception(f"SPARQL query execution error: {str(e)}")
+        except Exception:
+            logger.exception(f"endpoint_url: {str(endpoint_url)} TITLE : {str(title)}")
             results = None
         return results
 

--- a/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
+++ b/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
@@ -29,7 +29,6 @@ class SPARQLDataProviderForConnectors(object):
     @timing
     def _get_data(self):
         endpoint_url = self.context.endpoint_url
-        title = self.context.title
         query = self.context.sparql_query
 
         sparql = SPARQLWrapper(endpoint_url)
@@ -37,9 +36,9 @@ class SPARQLDataProviderForConnectors(object):
         sparql.setReturnFormat(JSON)
 
         try:
-            results = sparql.query().convert()
+            results = sparql.query().conver()
         except Exception:
-            logger.exception(f"endpoint_url: {str(endpoint_url)} TITLE : {str(title)}")
+            logger.exception(f"endpoint_url: {endpoint_url} TITLE : {self.context.title}")
             results = None
         return results
 

--- a/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
+++ b/plone-5/instance/src/ukstats.sparql_dataconnector/src/ukstats/sparql_dataconnector/adapter.py
@@ -36,7 +36,7 @@ class SPARQLDataProviderForConnectors(object):
         sparql.setReturnFormat(JSON)
 
         try:
-            results = sparql.query().conver()
+            results = sparql.query().convert()
         except Exception:
             logger.exception(f"endpoint_url: {endpoint_url} TITLE : {self.context.title}")
             results = None


### PR DESCRIPTION
#884 

Testing:
This modification can be tested by introducing a breaking chnage in the code so the exception is triggered.
example: ```       try:
            results = sparql.query().conver()```
deleting a letter "t" from the convert function.