### PR TITLE
fix volto builds, tidy up all builds

### DIFF
--- a/builds/plone-latest.yml
+++ b/builds/plone-latest.yml
@@ -1,13 +1,5 @@
 steps:
 
-  # "kaniko" is a build runner whose sole job is to build
-  # container images optimised for use on k8s.
-  # destination is just where on our infrastructure we store
-  # these images.
-  # by default it looks for Dockerfile in the repo root and builds
-  # that though other locations can be specified.
-  # For why we build the image twice with different tags, see
-  # the cicd README.
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - >-
@@ -33,4 +25,4 @@ steps:
         plone=${_IMAGE_REPOSITORY}/plone:$SHORT_SHA
 timeout: 7200s  # 2 hours !!
 options:
-  - machine_type = "E2_HIGHCPU_32"
+  machineType: E2_HIGHCPU_32

--- a/builds/plone-release.yml
+++ b/builds/plone-release.yml
@@ -1,13 +1,5 @@
 steps:
 
-  # "kaniko" is a build runner whose sole job is to build
-  # container images optimised for use on k8s.
-  # destination is just where on our infrastructure we store
-  # these images.
-  # by default it looks for Dockerfile in the repo root and builds
-  # that though other locations can be specified.
-  # For why we build the image twice with different tags, see
-  # the cicd README.
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
       - >-
@@ -33,4 +25,4 @@ steps:
         plone=${_IMAGE_REPOSITORY}/plone:$TAG_NAME
 timeout: 7200s  # 2 hours !!
 options:
-  - machine_type = "E2_HIGHCPU_32"
+  machineType: E2_HIGHCPU_32

--- a/builds/volto-latest.yml
+++ b/builds/volto-latest.yml
@@ -1,14 +1,5 @@
 steps:
 
-  # "kaniko" is a build runner whose sole job is to build
-  # container images optimised for use on k8s.
-  # destination is just where on our infrastructure we store
-  # these images.
-  # by default it looks for Dockerfile in the repo root and builds
-  # that though other locations can be specified.
-  # For why we build the image twice with different tags, see
-  # the cicd README.
-
   # Builds Volto-test from Dockerfile-test and image is pushed to artifact registry
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
@@ -85,4 +76,4 @@ steps:
         volto-dcms=${_IMAGE_REPOSITORY}/volto:$SHORT_SHA
 timeout: 7200s  # 2 hours !!
 options:
-  - machine_type = "E2_HIGHCPU_32"
+  machineType: E2_HIGHCPU_32

--- a/builds/volto-release.yml
+++ b/builds/volto-release.yml
@@ -1,14 +1,5 @@
 steps:
 
-  # "kaniko" is a build runner whose sole job is to build
-  # container images optimised for use on k8s.
-  # destination is just where on our infrastructure we store
-  # these images.
-  # by default it looks for Dockerfile in the repo root and builds
-  # that though other locations can be specified.
-  # For why we build the image twice with different tags, see
-  # the cicd README.
-
 # Builds Volto-test from Dockerfile-test and image is pushed to artifact registry
   - name: 'gcr.io/kaniko-project/executor:latest'
     args:
@@ -85,4 +76,4 @@ steps:
         volto-dcms=${_IMAGE_REPOSITORY}/volto:$TAG_NAME
 timeout: 7200s  # 2 hours !!
 options:
-  - machine_type = "E2_HIGHCPU_32"
+  machineType: E2_HIGHCPU_32


### PR DESCRIPTION
when we were transitioning from terraform defined builds to builds defined with yaml per repo, a little bit of terraform syntax lingered in place of yaml and I didn't spot it at PR.

i.e

```
- machine_type = "E2_HIGHCPU_32"
```

should be

```
machineType: E2_HIGHCPU_32
```

that's all this is plus removing some excessive comments carried over from the example.