### PR TITLE
Fix formatting on plone-latest build context argument

### DIFF
--- a/builds/plone-latest.yml
+++ b/builds/plone-latest.yml
@@ -6,7 +6,8 @@ steps:
         --destination=${_IMAGE_REPOSITORY}/plone:latest
       - >-
         --destination=${_IMAGE_REPOSITORY}/plone:$SHORT_SHA
-      - context=dir://plone-5
+      - >-
+        --context=dir://plone-5
 
   # This uses the kubectl runner (a container designed to interact
   # with k8s via kubectl) to update the image defined in the k8s deployment

--- a/builds/plone-release.yml
+++ b/builds/plone-release.yml
@@ -6,7 +6,8 @@ steps:
         --destination=${_IMAGE_REPOSITORY}/plone:latest-release
       - >-
         --destination=${_IMAGE_REPOSITORY}/plone:$TAG_NAME
-      - context=dir://plone-5
+      - >-
+        --context=dir://plone-5
 
   # This uses the kubectl runner (a container designed to interact
   # with k8s via kubectl) to update the image defined in the k8s deployment

--- a/builds/volto-latest.yml
+++ b/builds/volto-latest.yml
@@ -7,7 +7,8 @@ steps:
         --destination=${_IMAGE_REPOSITORY}/volto-test:latest
       - >-
         --destination=${_IMAGE_REPOSITORY}/volto-test:$SHORT_SHA
-      - context=dir://volto
+      - >-
+        --context=dir://volto
       - Dockerfile=Dockerfile-test
 
 # Run volto tests using the volto test container and Volto tests are run using container volume

--- a/builds/volto-release.yml
+++ b/builds/volto-release.yml
@@ -7,7 +7,8 @@ steps:
         --destination=${_IMAGE_REPOSITORY}/volto-test:latest-release
       - >-
         --destination=${_IMAGE_REPOSITORY}/volto-test:$TAG_NAME
-      - context=dir://volto
+      - >-
+        --context=dir://volto
       - Dockerfile=Dockerfile-test
 
 # Run volto tests using the volto test container and Volto tests are run using container volume


### PR DESCRIPTION
When we moved the build steps back into these repos a few weeks back (https://github.com/GSS-Cogs/idpd-cicd/pull/11/files) there was a formatting issue with the `--context=` argument so it was being passed in as a new command rather than additional argument.

This PR should mean our builds work again 🤞 